### PR TITLE
Add XDR types for Clawback and LiquidityPool operation results

### DIFF
--- a/lib/xdr/operations/clawback_claimable_balance_result.ex
+++ b/lib/xdr/operations/clawback_claimable_balance_result.ex
@@ -1,0 +1,58 @@
+defmodule Stellar.XDR.Operations.ClawbackClaimableBalanceResult do
+  @moduledoc """
+  Representation of Stellar `ClawbackClaimableBalanceResult` type.
+  """
+  alias Stellar.XDR.Void
+  alias Stellar.XDR.Operations.ClawbackClaimableBalanceResultCode
+
+  @behaviour XDR.Declaration
+
+  @arms [CLAWBACK_CLAIMABLE_BALANCE_SUCCESS: Void, default: Void]
+
+  @type t :: %__MODULE__{result: any(), code: ClawbackClaimableBalanceResultCode.t()}
+
+  defstruct [:result, :code]
+
+  @spec new(result :: any(), code :: ClawbackClaimableBalanceResultCode.t()) :: t()
+  def new(result, %ClawbackClaimableBalanceResultCode{} = code),
+    do: %__MODULE__{result: result, code: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{result: result, code: code}) do
+    code
+    |> XDR.Union.new(@arms, result)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{result: result, code: code}) do
+    code
+    |> XDR.Union.new(@arms, result)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{code, result}, rest}} -> {:ok, {new(result, code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{code, result}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(result, code), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> ClawbackClaimableBalanceResultCode.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/operations/clawback_claimable_balance_result_code.ex
+++ b/lib/xdr/operations/clawback_claimable_balance_result_code.ex
@@ -1,0 +1,56 @@
+defmodule Stellar.XDR.Operations.ClawbackClaimableBalanceResultCode do
+  @moduledoc """
+  Representation of Stellar `ClawbackClaimableBalanceResultCode` type.
+  """
+  @behaviour XDR.Declaration
+
+  @declarations [
+    # success
+    CLAWBACK_CLAIMABLE_BALANCE_SUCCESS: 0,
+    # failure
+    CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST: -1,
+    CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER: -2,
+    CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED: -3
+  ]
+
+  @enum_spec %XDR.Enum{declarations: @declarations, identifier: nil}
+
+  @type t :: %__MODULE__{identifier: atom()}
+
+  defstruct [:identifier]
+
+  @spec new(code :: atom()) :: t()
+  def new(code), do: %__MODULE__{identifier: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @enum_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Enum.decode_xdr(bytes, spec) do
+      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @enum_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(code), rest}
+  end
+end

--- a/lib/xdr/operations/clawback_result.ex
+++ b/lib/xdr/operations/clawback_result.ex
@@ -1,0 +1,58 @@
+defmodule Stellar.XDR.Operations.ClawbackResult do
+  @moduledoc """
+  Representation of Stellar `ClawbackResult` type.
+  """
+  alias Stellar.XDR.Void
+  alias Stellar.XDR.Operations.ClawbackResultCode
+
+  @behaviour XDR.Declaration
+
+  @arms [CLAWBACK_SUCCESS: Void, default: Void]
+
+  @type t :: %__MODULE__{result: any(), code: ClawbackResultCode.t()}
+
+  defstruct [:result, :code]
+
+  @spec new(result :: any(), code :: ClawbackResultCode.t()) :: t()
+  def new(result, %ClawbackResultCode{} = code),
+    do: %__MODULE__{result: result, code: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{result: result, code: code}) do
+    code
+    |> XDR.Union.new(@arms, result)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{result: result, code: code}) do
+    code
+    |> XDR.Union.new(@arms, result)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{code, result}, rest}} -> {:ok, {new(result, code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{code, result}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(result, code), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> ClawbackResultCode.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/operations/clawback_result_code.ex
+++ b/lib/xdr/operations/clawback_result_code.ex
@@ -1,0 +1,57 @@
+defmodule Stellar.XDR.Operations.ClawbackResultCode do
+  @moduledoc """
+  Representation of Stellar `ClawbackResultCode` type.
+  """
+  @behaviour XDR.Declaration
+
+  @declarations [
+    # success
+    CLAWBACK_SUCCESS: 0,
+    # failure
+    CLAWBACK_MALFORMED: -1,
+    CLAWBACK_NOT_CLAWBACK_ENABLED: -2,
+    CLAWBACK_NO_TRUST: -3,
+    CLAWBACK_UNDERFUNDED: -4
+  ]
+
+  @enum_spec %XDR.Enum{declarations: @declarations, identifier: nil}
+
+  @type t :: %__MODULE__{identifier: atom()}
+
+  defstruct [:identifier]
+
+  @spec new(code :: atom()) :: t()
+  def new(code), do: %__MODULE__{identifier: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @enum_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Enum.decode_xdr(bytes, spec) do
+      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @enum_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(code), rest}
+  end
+end

--- a/lib/xdr/operations/liquidity_pool_deposit_result.ex
+++ b/lib/xdr/operations/liquidity_pool_deposit_result.ex
@@ -1,0 +1,58 @@
+defmodule Stellar.XDR.Operations.LiquidityPoolDepositResult do
+  @moduledoc """
+  Representation of Stellar `LiquidityPoolDepositResult` type.
+  """
+  alias Stellar.XDR.Void
+  alias Stellar.XDR.Operations.LiquidityPoolDepositResultCode
+
+  @behaviour XDR.Declaration
+
+  @arms [LIQUIDITY_POOL_DEPOSIT_SUCCESS: Void, default: Void]
+
+  @type t :: %__MODULE__{result: any(), code: LiquidityPoolDepositResultCode.t()}
+
+  defstruct [:result, :code]
+
+  @spec new(result :: any(), code :: LiquidityPoolDepositResultCode.t()) :: t()
+  def new(result, %LiquidityPoolDepositResultCode{} = code),
+    do: %__MODULE__{result: result, code: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{result: result, code: code}) do
+    code
+    |> XDR.Union.new(@arms, result)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{result: result, code: code}) do
+    code
+    |> XDR.Union.new(@arms, result)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{code, result}, rest}} -> {:ok, {new(result, code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{code, result}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(result, code), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> LiquidityPoolDepositResultCode.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/operations/liquidity_pool_deposit_result_code.ex
+++ b/lib/xdr/operations/liquidity_pool_deposit_result_code.ex
@@ -1,0 +1,66 @@
+defmodule Stellar.XDR.Operations.LiquidityPoolDepositResultCode do
+  @moduledoc """
+  Representation of Stellar `LiquidityPoolDepositResultCode` type.
+  """
+  @behaviour XDR.Declaration
+
+  @declarations [
+    # success
+    LIQUIDITY_POOL_DEPOSIT_SUCCESS: 0,
+    # bad input
+    LIQUIDITY_POOL_DEPOSIT_MALFORMED: -1,
+    # no trust line for one of the assets
+    LIQUIDITY_POOL_DEPOSIT_NO_TRUST: -2,
+    # not authorized for one of the assets
+    LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED: -3,
+    # not enough balance for one of the assets
+    LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED: -4,
+    # pool share trust line doesn't have sufficient limit
+    LIQUIDITY_POOL_DEPOSIT_LINE_FULL: -5,
+    # deposit price outside bounds
+    LIQUIDITY_POOL_DEPOSIT_BAD_PRICE: -6,
+    # pool reserves are full
+    LIQUIDITY_POOL_DEPOSIT_POOL_FULL: -7
+  ]
+
+  @enum_spec %XDR.Enum{declarations: @declarations, identifier: nil}
+
+  @type t :: %__MODULE__{identifier: atom()}
+
+  defstruct [:identifier]
+
+  @spec new(code :: atom()) :: t()
+  def new(code), do: %__MODULE__{identifier: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @enum_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Enum.decode_xdr(bytes, spec) do
+      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @enum_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(code), rest}
+  end
+end

--- a/lib/xdr/operations/liquidity_pool_withdraw_result.ex
+++ b/lib/xdr/operations/liquidity_pool_withdraw_result.ex
@@ -1,0 +1,58 @@
+defmodule Stellar.XDR.Operations.LiquidityPoolWithdrawResult do
+  @moduledoc """
+  Representation of Stellar `LiquidityPoolWithdrawResult` type.
+  """
+  alias Stellar.XDR.Void
+  alias Stellar.XDR.Operations.LiquidityPoolWithdrawResultCode
+
+  @behaviour XDR.Declaration
+
+  @arms [LIQUIDITY_POOL_WITHDRAW_SUCCESS: Void, default: Void]
+
+  @type t :: %__MODULE__{result: any(), code: LiquidityPoolWithdrawResultCode.t()}
+
+  defstruct [:result, :code]
+
+  @spec new(result :: any(), code :: LiquidityPoolWithdrawResultCode.t()) :: t()
+  def new(result, %LiquidityPoolWithdrawResultCode{} = code),
+    do: %__MODULE__{result: result, code: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{result: result, code: code}) do
+    code
+    |> XDR.Union.new(@arms, result)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{result: result, code: code}) do
+    code
+    |> XDR.Union.new(@arms, result)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{code, result}, rest}} -> {:ok, {new(result, code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{code, result}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(result, code), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> LiquidityPoolWithdrawResultCode.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/operations/liquidity_pool_withdraw_result_code.ex
+++ b/lib/xdr/operations/liquidity_pool_withdraw_result_code.ex
@@ -1,0 +1,62 @@
+defmodule Stellar.XDR.Operations.LiquidityPoolWithdrawResultCode do
+  @moduledoc """
+  Representation of Stellar `LiquidityPoolWithdrawResultCode` type.
+  """
+  @behaviour XDR.Declaration
+
+  @declarations [
+    # success
+    LIQUIDITY_POOL_WITHDRAW_SUCCESS: 0,
+    # bad input
+    LIQUIDITY_POOL_WITHDRAW_MALFORMED: -1,
+    # no trust line for one of the assets
+    LIQUIDITY_POOL_WITHDRAW_NO_TRUST: -2,
+    # not enough balance of the pool share
+    LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED: -3,
+    # would go above limit for one of the assets
+    LIQUIDITY_POOL_WITHDRAW_LINE_FULL: -4,
+    # didn't withdraw enough
+    LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM: -5
+  ]
+
+  @enum_spec %XDR.Enum{declarations: @declarations, identifier: nil}
+
+  @type t :: %__MODULE__{identifier: atom()}
+
+  defstruct [:identifier]
+
+  @spec new(code :: atom()) :: t()
+  def new(code), do: %__MODULE__{identifier: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @enum_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Enum.decode_xdr(bytes, spec) do
+      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @enum_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(code), rest}
+  end
+end

--- a/test/xdr/operations/clawback_claimable_balance_result_code_test.exs
+++ b/test/xdr/operations/clawback_claimable_balance_result_code_test.exs
@@ -1,0 +1,52 @@
+defmodule Stellar.XDR.Operations.ClawbackClaimableBalanceResultCodeTest do
+  use ExUnit.Case
+
+  alias Stellar.XDR.Operations.ClawbackClaimableBalanceResultCode
+
+  describe "ClawbackClaimableBalanceResultCode" do
+    setup do
+      %{
+        code: :CLAWBACK_CLAIMABLE_BALANCE_SUCCESS,
+        result: ClawbackClaimableBalanceResultCode.new(:CLAWBACK_CLAIMABLE_BALANCE_SUCCESS),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{code: type} do
+      %ClawbackClaimableBalanceResultCode{identifier: ^type} =
+        ClawbackClaimableBalanceResultCode.new(type)
+    end
+
+    test "encode_xdr/1", %{result: result, binary: binary} do
+      {:ok, ^binary} = ClawbackClaimableBalanceResultCode.encode_xdr(result)
+    end
+
+    test "encode_xdr/1 with an invalid code" do
+      {:error, :invalid_key} =
+        ClawbackClaimableBalanceResultCode.encode_xdr(%ClawbackClaimableBalanceResultCode{
+          identifier: :TEST
+        })
+    end
+
+    test "encode_xdr!/1", %{result: result, binary: binary} do
+      ^binary = ClawbackClaimableBalanceResultCode.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{result: result, binary: binary} do
+      {:ok, {^result, ""}} = ClawbackClaimableBalanceResultCode.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid declaration" do
+      {:error, :invalid_key} = ClawbackClaimableBalanceResultCode.decode_xdr(<<1, 0, 0, 1>>)
+    end
+
+    test "decode_xdr!/2", %{result: result, binary: binary} do
+      {^result, ^binary} = ClawbackClaimableBalanceResultCode.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 with an error code" do
+      {%ClawbackClaimableBalanceResultCode{identifier: :CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER},
+       ""} = ClawbackClaimableBalanceResultCode.decode_xdr!(<<255, 255, 255, 254>>)
+    end
+  end
+end

--- a/test/xdr/operations/clawback_claimable_balance_result_test.exs
+++ b/test/xdr/operations/clawback_claimable_balance_result_test.exs
@@ -1,0 +1,61 @@
+defmodule Stellar.XDR.Operations.ClawbackClaimableBalanceResultTest do
+  use ExUnit.Case
+
+  alias Stellar.XDR.Void
+
+  alias Stellar.XDR.Operations.{
+    ClawbackClaimableBalanceResult,
+    ClawbackClaimableBalanceResultCode
+  }
+
+  describe "ClawbackClaimableBalanceResult" do
+    setup do
+      code = ClawbackClaimableBalanceResultCode.new(:CLAWBACK_CLAIMABLE_BALANCE_SUCCESS)
+
+      %{
+        code: code,
+        value: Void.new(),
+        result: ClawbackClaimableBalanceResult.new(Void.new(), code),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{code: code, value: value} do
+      %ClawbackClaimableBalanceResult{code: ^code, result: ^value} =
+        ClawbackClaimableBalanceResult.new(value, code)
+    end
+
+    test "encode_xdr/1", %{result: result, binary: binary} do
+      {:ok, ^binary} = ClawbackClaimableBalanceResult.encode_xdr(result)
+    end
+
+    test "encode_xdr!/1", %{result: result, binary: binary} do
+      ^binary = ClawbackClaimableBalanceResult.encode_xdr!(result)
+    end
+
+    test "encode_xdr!/1 with a default value", %{code: code, binary: binary} do
+      result = ClawbackClaimableBalanceResult.new("TEST", code)
+      ^binary = ClawbackClaimableBalanceResult.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{result: result, binary: binary} do
+      {:ok, {^result, ""}} = ClawbackClaimableBalanceResult.decode_xdr(binary)
+    end
+
+    test "decode_xdr!/2", %{result: result, binary: binary} do
+      {^result, ^binary} = ClawbackClaimableBalanceResult.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 an error code" do
+      {%ClawbackClaimableBalanceResult{
+         code: %ClawbackClaimableBalanceResultCode{
+           identifier: :CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER
+         }
+       }, ""} = ClawbackClaimableBalanceResult.decode_xdr!(<<255, 255, 255, 254>>)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = ClawbackClaimableBalanceResult.decode_xdr(123)
+    end
+  end
+end

--- a/test/xdr/operations/clawback_result_code_test.exs
+++ b/test/xdr/operations/clawback_result_code_test.exs
@@ -1,0 +1,49 @@
+defmodule Stellar.XDR.Operations.ClawbackResultCodeTest do
+  use ExUnit.Case
+
+  alias Stellar.XDR.Operations.ClawbackResultCode
+
+  describe "ClawbackResultCode" do
+    setup do
+      %{
+        code: :CLAWBACK_SUCCESS,
+        result: ClawbackResultCode.new(:CLAWBACK_SUCCESS),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{code: type} do
+      %ClawbackResultCode{identifier: ^type} = ClawbackResultCode.new(type)
+    end
+
+    test "encode_xdr/1", %{result: result, binary: binary} do
+      {:ok, ^binary} = ClawbackResultCode.encode_xdr(result)
+    end
+
+    test "encode_xdr/1 with an invalid code" do
+      {:error, :invalid_key} =
+        ClawbackResultCode.encode_xdr(%ClawbackResultCode{identifier: :TEST})
+    end
+
+    test "encode_xdr!/1", %{result: result, binary: binary} do
+      ^binary = ClawbackResultCode.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{result: result, binary: binary} do
+      {:ok, {^result, ""}} = ClawbackResultCode.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid declaration" do
+      {:error, :invalid_key} = ClawbackResultCode.decode_xdr(<<1, 0, 0, 1>>)
+    end
+
+    test "decode_xdr!/2", %{result: result, binary: binary} do
+      {^result, ^binary} = ClawbackResultCode.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 with an error code" do
+      {%ClawbackResultCode{identifier: :CLAWBACK_NOT_CLAWBACK_ENABLED}, ""} =
+        ClawbackResultCode.decode_xdr!(<<255, 255, 255, 254>>)
+    end
+  end
+end

--- a/test/xdr/operations/clawback_result_test.exs
+++ b/test/xdr/operations/clawback_result_test.exs
@@ -1,0 +1,54 @@
+defmodule Stellar.XDR.Operations.ClawbackResultTest do
+  use ExUnit.Case
+
+  alias Stellar.XDR.Void
+  alias Stellar.XDR.Operations.{ClawbackResult, ClawbackResultCode}
+
+  describe "ClawbackResult" do
+    setup do
+      code = ClawbackResultCode.new(:CLAWBACK_SUCCESS)
+
+      %{
+        code: code,
+        value: Void.new(),
+        result: ClawbackResult.new(Void.new(), code),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{code: code, value: value} do
+      %ClawbackResult{code: ^code, result: ^value} = ClawbackResult.new(value, code)
+    end
+
+    test "encode_xdr/1", %{result: result, binary: binary} do
+      {:ok, ^binary} = ClawbackResult.encode_xdr(result)
+    end
+
+    test "encode_xdr!/1", %{result: result, binary: binary} do
+      ^binary = ClawbackResult.encode_xdr!(result)
+    end
+
+    test "encode_xdr!/1 with a default value", %{code: code, binary: binary} do
+      result = ClawbackResult.new("TEST", code)
+      ^binary = ClawbackResult.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{result: result, binary: binary} do
+      {:ok, {^result, ""}} = ClawbackResult.decode_xdr(binary)
+    end
+
+    test "decode_xdr!/2", %{result: result, binary: binary} do
+      {^result, ^binary} = ClawbackResult.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 an error code" do
+      {%ClawbackResult{
+         code: %ClawbackResultCode{identifier: :CLAWBACK_NOT_CLAWBACK_ENABLED}
+       }, ""} = ClawbackResult.decode_xdr!(<<255, 255, 255, 254>>)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = ClawbackResult.decode_xdr(123)
+    end
+  end
+end

--- a/test/xdr/operations/liquidity_pool_deposit_result_code_test.exs
+++ b/test/xdr/operations/liquidity_pool_deposit_result_code_test.exs
@@ -1,0 +1,52 @@
+defmodule Stellar.XDR.Operations.LiquidityPoolDepositResultCodeTest do
+  use ExUnit.Case
+
+  alias Stellar.XDR.Operations.LiquidityPoolDepositResultCode
+
+  describe "LiquidityPoolDepositResultCode" do
+    setup do
+      %{
+        code: :LIQUIDITY_POOL_DEPOSIT_SUCCESS,
+        result: LiquidityPoolDepositResultCode.new(:LIQUIDITY_POOL_DEPOSIT_SUCCESS),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{code: type} do
+      %LiquidityPoolDepositResultCode{identifier: ^type} =
+        LiquidityPoolDepositResultCode.new(type)
+    end
+
+    test "encode_xdr/1", %{result: result, binary: binary} do
+      {:ok, ^binary} = LiquidityPoolDepositResultCode.encode_xdr(result)
+    end
+
+    test "encode_xdr/1 with an invalid code" do
+      {:error, :invalid_key} =
+        LiquidityPoolDepositResultCode.encode_xdr(%LiquidityPoolDepositResultCode{
+          identifier: :TEST
+        })
+    end
+
+    test "encode_xdr!/1", %{result: result, binary: binary} do
+      ^binary = LiquidityPoolDepositResultCode.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{result: result, binary: binary} do
+      {:ok, {^result, ""}} = LiquidityPoolDepositResultCode.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid declaration" do
+      {:error, :invalid_key} = LiquidityPoolDepositResultCode.decode_xdr(<<1, 0, 0, 1>>)
+    end
+
+    test "decode_xdr!/2", %{result: result, binary: binary} do
+      {^result, ^binary} = LiquidityPoolDepositResultCode.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 with an error code" do
+      {%LiquidityPoolDepositResultCode{identifier: :LIQUIDITY_POOL_DEPOSIT_NO_TRUST}, ""} =
+        LiquidityPoolDepositResultCode.decode_xdr!(<<255, 255, 255, 254>>)
+    end
+  end
+end

--- a/test/xdr/operations/liquidity_pool_deposit_result_test.exs
+++ b/test/xdr/operations/liquidity_pool_deposit_result_test.exs
@@ -1,0 +1,55 @@
+defmodule Stellar.XDR.Operations.LiquidityPoolDepositResultTest do
+  use ExUnit.Case
+
+  alias Stellar.XDR.Void
+  alias Stellar.XDR.Operations.{LiquidityPoolDepositResult, LiquidityPoolDepositResultCode}
+
+  describe "LiquidityPoolDepositResult" do
+    setup do
+      code = LiquidityPoolDepositResultCode.new(:LIQUIDITY_POOL_DEPOSIT_SUCCESS)
+
+      %{
+        code: code,
+        value: Void.new(),
+        result: LiquidityPoolDepositResult.new(Void.new(), code),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{code: code, value: value} do
+      %LiquidityPoolDepositResult{code: ^code, result: ^value} =
+        LiquidityPoolDepositResult.new(value, code)
+    end
+
+    test "encode_xdr/1", %{result: result, binary: binary} do
+      {:ok, ^binary} = LiquidityPoolDepositResult.encode_xdr(result)
+    end
+
+    test "encode_xdr!/1", %{result: result, binary: binary} do
+      ^binary = LiquidityPoolDepositResult.encode_xdr!(result)
+    end
+
+    test "encode_xdr!/1 with a default value", %{code: code, binary: binary} do
+      result = LiquidityPoolDepositResult.new("TEST", code)
+      ^binary = LiquidityPoolDepositResult.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{result: result, binary: binary} do
+      {:ok, {^result, ""}} = LiquidityPoolDepositResult.decode_xdr(binary)
+    end
+
+    test "decode_xdr!/2", %{result: result, binary: binary} do
+      {^result, ^binary} = LiquidityPoolDepositResult.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 an error code" do
+      {%LiquidityPoolDepositResult{
+         code: %LiquidityPoolDepositResultCode{identifier: :LIQUIDITY_POOL_DEPOSIT_NO_TRUST}
+       }, ""} = LiquidityPoolDepositResult.decode_xdr!(<<255, 255, 255, 254>>)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = LiquidityPoolDepositResult.decode_xdr(123)
+    end
+  end
+end

--- a/test/xdr/operations/liquidity_pool_withdraw_result_code_test.exs
+++ b/test/xdr/operations/liquidity_pool_withdraw_result_code_test.exs
@@ -1,0 +1,52 @@
+defmodule Stellar.XDR.Operations.LiquidityPoolWithdrawResultCodeTest do
+  use ExUnit.Case
+
+  alias Stellar.XDR.Operations.LiquidityPoolWithdrawResultCode
+
+  describe "LiquidityPoolWithdrawResultCode" do
+    setup do
+      %{
+        code: :LIQUIDITY_POOL_WITHDRAW_SUCCESS,
+        result: LiquidityPoolWithdrawResultCode.new(:LIQUIDITY_POOL_WITHDRAW_SUCCESS),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{code: type} do
+      %LiquidityPoolWithdrawResultCode{identifier: ^type} =
+        LiquidityPoolWithdrawResultCode.new(type)
+    end
+
+    test "encode_xdr/1", %{result: result, binary: binary} do
+      {:ok, ^binary} = LiquidityPoolWithdrawResultCode.encode_xdr(result)
+    end
+
+    test "encode_xdr/1 with an invalid code" do
+      {:error, :invalid_key} =
+        LiquidityPoolWithdrawResultCode.encode_xdr(%LiquidityPoolWithdrawResultCode{
+          identifier: :TEST
+        })
+    end
+
+    test "encode_xdr!/1", %{result: result, binary: binary} do
+      ^binary = LiquidityPoolWithdrawResultCode.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{result: result, binary: binary} do
+      {:ok, {^result, ""}} = LiquidityPoolWithdrawResultCode.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid declaration" do
+      {:error, :invalid_key} = LiquidityPoolWithdrawResultCode.decode_xdr(<<1, 0, 0, 1>>)
+    end
+
+    test "decode_xdr!/2", %{result: result, binary: binary} do
+      {^result, ^binary} = LiquidityPoolWithdrawResultCode.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 with an error code" do
+      {%LiquidityPoolWithdrawResultCode{identifier: :LIQUIDITY_POOL_WITHDRAW_NO_TRUST}, ""} =
+        LiquidityPoolWithdrawResultCode.decode_xdr!(<<255, 255, 255, 254>>)
+    end
+  end
+end

--- a/test/xdr/operations/liquidity_pool_withdraw_result_test.exs
+++ b/test/xdr/operations/liquidity_pool_withdraw_result_test.exs
@@ -1,0 +1,55 @@
+defmodule Stellar.XDR.Operations.LiquidityPoolWithdrawResultTest do
+  use ExUnit.Case
+
+  alias Stellar.XDR.Void
+  alias Stellar.XDR.Operations.{LiquidityPoolWithdrawResult, LiquidityPoolWithdrawResultCode}
+
+  describe "LiquidityPoolWithdrawResult" do
+    setup do
+      code = LiquidityPoolWithdrawResultCode.new(:LIQUIDITY_POOL_WITHDRAW_SUCCESS)
+
+      %{
+        code: code,
+        value: Void.new(),
+        result: LiquidityPoolWithdrawResult.new(Void.new(), code),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{code: code, value: value} do
+      %LiquidityPoolWithdrawResult{code: ^code, result: ^value} =
+        LiquidityPoolWithdrawResult.new(value, code)
+    end
+
+    test "encode_xdr/1", %{result: result, binary: binary} do
+      {:ok, ^binary} = LiquidityPoolWithdrawResult.encode_xdr(result)
+    end
+
+    test "encode_xdr!/1", %{result: result, binary: binary} do
+      ^binary = LiquidityPoolWithdrawResult.encode_xdr!(result)
+    end
+
+    test "encode_xdr!/1 with a default value", %{code: code, binary: binary} do
+      result = LiquidityPoolWithdrawResult.new("TEST", code)
+      ^binary = LiquidityPoolWithdrawResult.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{result: result, binary: binary} do
+      {:ok, {^result, ""}} = LiquidityPoolWithdrawResult.decode_xdr(binary)
+    end
+
+    test "decode_xdr!/2", %{result: result, binary: binary} do
+      {^result, ^binary} = LiquidityPoolWithdrawResult.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 an error code" do
+      {%LiquidityPoolWithdrawResult{
+         code: %LiquidityPoolWithdrawResultCode{identifier: :LIQUIDITY_POOL_WITHDRAW_NO_TRUST}
+       }, ""} = LiquidityPoolWithdrawResult.decode_xdr!(<<255, 255, 255, 254>>)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = LiquidityPoolWithdrawResult.decode_xdr(123)
+    end
+  end
+end


### PR DESCRIPTION
This is part of #78, includes the following XDR types

* ClawbackResult
* ClawbackClaimableBalanceResult
* LiquidityPoolDepositResult
* LiquidityPoolWithdrawResult