### PR TITLE
Add TrustLineEntry asset

### DIFF
--- a/lib/xdr/ledger_entries/trust_line_entry.ex
+++ b/lib/xdr/ledger_entries/trust_line_entry.ex
@@ -2,7 +2,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
   @moduledoc """
   Representation of Stellar `TrustLineEntry` type.
   """
-  alias StellarBase.XDR.{AccountID, TrustLineAsset, Int64, UInt32, Ext}
+  alias StellarBase.XDR.{AccountID, TrustLineAsset, Int64, UInt32, TrustLineEntryExt}
 
   @behaviour XDR.Declaration
 
@@ -12,7 +12,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
                  balance: Int64,
                  limit: Int64,
                  flags: UInt32,
-                 ext: Ext
+                 trust_line_entry_ext: TrustLineEntryExt
                )
 
   @type t :: %__MODULE__{
@@ -21,7 +21,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
           balance: Int64.t(),
           limit: Int64.t(),
           flags: UInt32.t(),
-          ext: Ext.t()
+          trust_line_entry_ext: TrustLineEntryExt.t()
         }
 
   defstruct [
@@ -30,7 +30,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
     :balance,
     :limit,
     :flags,
-    :ext
+    :trust_line_entry_ext
   ]
 
   @spec new(
@@ -39,7 +39,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
           balance :: Int64.t(),
           limit :: Int64.t(),
           flags :: UInt32.t(),
-          ext :: Ext.t()
+          trust_line_entry_ext :: TrustLineEntryExt.t()
         ) :: t()
   def new(
         %AccountID{} = account_id,
@@ -47,7 +47,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
         %Int64{} = balance,
         %Int64{} = limit,
         %UInt32{} = flags,
-        %Ext{} = ext
+        %TrustLineEntryExt{} = trust_line_entry_ext
       ),
       do: %__MODULE__{
         account_id: account_id,
@@ -55,7 +55,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
         balance: balance,
         limit: limit,
         flags: flags,
-        ext: ext
+        trust_line_entry_ext: trust_line_entry_ext
       }
 
   @impl true
@@ -65,7 +65,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
         balance: balance,
         limit: limit,
         flags: flags,
-        ext: ext
+        trust_line_entry_ext: trust_line_entry_ext
       }) do
     [
       account_id: account_id,
@@ -73,7 +73,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
       balance: balance,
       limit: limit,
       flags: flags,
-      ext: ext
+      trust_line_entry_ext: trust_line_entry_ext
     ]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr()
@@ -86,7 +86,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
         balance: balance,
         limit: limit,
         flags: flags,
-        ext: ext
+        trust_line_entry_ext: trust_line_entry_ext
       }) do
     [
       account_id: account_id,
@@ -94,7 +94,7 @@ defmodule StellarBase.XDR.TrustLineEntry do
       balance: balance,
       limit: limit,
       flags: flags,
-      ext: ext
+      trust_line_entry_ext: trust_line_entry_ext
     ]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr!()
@@ -113,10 +113,10 @@ defmodule StellarBase.XDR.TrustLineEntry do
             balance: balance,
             limit: limit,
             flags: flags,
-            ext: ext
+            trust_line_entry_ext: trust_line_entry_ext
           ]
         }, rest}} ->
-        {:ok, {new(account_id, asset, balance, limit, flags, ext), rest}}
+        {:ok, {new(account_id, asset, balance, limit, flags, trust_line_entry_ext), rest}}
 
       error ->
         error
@@ -134,10 +134,10 @@ defmodule StellarBase.XDR.TrustLineEntry do
          balance: balance,
          limit: limit,
          flags: flags,
-         ext: ext
+         trust_line_entry_ext: trust_line_entry_ext
        ]
      }, rest} = XDR.Struct.decode_xdr!(bytes, struct)
 
-    {new(account_id, asset, balance, limit, flags, ext), rest}
+    {new(account_id, asset, balance, limit, flags, trust_line_entry_ext), rest}
   end
 end

--- a/lib/xdr/ledger_entries/trust_line_entry.ex
+++ b/lib/xdr/ledger_entries/trust_line_entry.ex
@@ -1,0 +1,143 @@
+defmodule StellarBase.XDR.TrustLineEntry do
+  @moduledoc """
+  Representation of Stellar `TrustLineEntry` type.
+  """
+  alias StellarBase.XDR.{AccountID, TrustLineAsset, Int64, UInt32, Ext}
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(
+                 account_id: AccountID,
+                 asset: TrustLineAsset,
+                 balance: Int64,
+                 limit: Int64,
+                 flags: UInt32,
+                 ext: Ext
+               )
+
+  @type t :: %__MODULE__{
+          account_id: AccountID.t(),
+          asset: TrustLineAsset.t(),
+          balance: Int64.t(),
+          limit: Int64.t(),
+          flags: UInt32.t(),
+          ext: Ext.t()
+        }
+
+  defstruct [
+    :account_id,
+    :asset,
+    :balance,
+    :limit,
+    :flags,
+    :ext
+  ]
+
+  @spec new(
+          account_id :: AccountID.t(),
+          asset :: TrustLineAsset.t(),
+          balance :: Int64.t(),
+          limit :: Int64.t(),
+          flags :: UInt32.t(),
+          ext :: Ext.t()
+        ) :: t()
+  def new(
+        %AccountID{} = account_id,
+        %TrustLineAsset{} = asset,
+        %Int64{} = balance,
+        %Int64{} = limit,
+        %UInt32{} = flags,
+        %Ext{} = ext
+      ),
+      do: %__MODULE__{
+        account_id: account_id,
+        asset: asset,
+        balance: balance,
+        limit: limit,
+        flags: flags,
+        ext: ext
+      }
+
+  @impl true
+  def encode_xdr(%__MODULE__{
+        account_id: account_id,
+        asset: asset,
+        balance: balance,
+        limit: limit,
+        flags: flags,
+        ext: ext
+      }) do
+    [
+      account_id: account_id,
+      asset: asset,
+      balance: balance,
+      limit: limit,
+      flags: flags,
+      ext: ext
+    ]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{
+        account_id: account_id,
+        asset: asset,
+        balance: balance,
+        limit: limit,
+        flags: flags,
+        ext: ext
+      }) do
+    [
+      account_id: account_id,
+      asset: asset,
+      balance: balance,
+      limit: limit,
+      flags: flags,
+      ext: ext
+    ]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok,
+       {%XDR.Struct{
+          components: [
+            account_id: account_id,
+            asset: asset,
+            balance: balance,
+            limit: limit,
+            flags: flags,
+            ext: ext
+          ]
+        }, rest}} ->
+        {:ok, {new(account_id, asset, balance, limit, flags, ext), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{
+       components: [
+         account_id: account_id,
+         asset: asset,
+         balance: balance,
+         limit: limit,
+         flags: flags,
+         ext: ext
+       ]
+     }, rest} = XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(account_id, asset, balance, limit, flags, ext), rest}
+  end
+end

--- a/lib/xdr/ledger_entries/trust_line_entry_ext.ex
+++ b/lib/xdr/ledger_entries/trust_line_entry_ext.ex
@@ -1,0 +1,64 @@
+defmodule StellarBase.XDR.TrustLineEntryExt do
+  @moduledoc """
+  Representation of Stellar `TrustLineEntryExt` type.
+  """
+  @behaviour XDR.Declaration
+
+  alias StellarBase.XDR.{Void, TrustLineEntryExtV1}
+
+  @arms %{0 => Void, 1 => TrustLineEntryExtV1}
+
+  @type value :: Void.t() | TrustLineEntryExtV1.t()
+
+  @type t :: %__MODULE__{value: value(), type: non_neg_integer()}
+
+  defstruct [:value, :type]
+
+  @spec new(value :: value(), type :: non_neg_integer()) :: t()
+  def new(value, type),
+    do: %__MODULE__{value: value, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{value: value, type: type}) do
+    type
+    |> XDR.Int.new()
+    |> XDR.Union.new(@arms, value)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{value: value, type: type}) do
+    type
+    |> XDR.Int.new()
+    |> XDR.Union.new(@arms, value)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  @spec decode_xdr(binary, map) ::
+          {:error, :invalid_arm | :not_binary | :not_list}
+          | {:ok, {StellarBase.XDR.TrustLineEntryExt.t(), binary}}
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{type, value}, rest}} -> {:ok, {new(value, type), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  @spec decode_xdr!(binary, map) :: {StellarBase.XDR.TrustLineEntryExt.t(), binary}
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{type, value}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(value, type), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    XDR.Int.new(0)
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/ledger_entries/trust_line_entry_ext.ex
+++ b/lib/xdr/ledger_entries/trust_line_entry_ext.ex
@@ -35,9 +35,6 @@ defmodule StellarBase.XDR.TrustLineEntryExt do
   end
 
   @impl true
-  @spec decode_xdr(binary, map) ::
-          {:error, :invalid_arm | :not_binary | :not_list}
-          | {:ok, {StellarBase.XDR.TrustLineEntryExt.t(), binary}}
   def decode_xdr(bytes, spec \\ union_spec())
 
   def decode_xdr(bytes, spec) do
@@ -48,7 +45,6 @@ defmodule StellarBase.XDR.TrustLineEntryExt do
   end
 
   @impl true
-  @spec decode_xdr!(binary, map) :: {StellarBase.XDR.TrustLineEntryExt.t(), binary}
   def decode_xdr!(bytes, spec \\ union_spec())
 
   def decode_xdr!(bytes, spec) do
@@ -58,7 +54,8 @@ defmodule StellarBase.XDR.TrustLineEntryExt do
 
   @spec union_spec() :: XDR.Union.t()
   defp union_spec do
-    XDR.Int.new(0)
+    0
+    |> XDR.Int.new()
     |> XDR.Union.new(@arms)
   end
 end

--- a/lib/xdr/ledger_entries/trust_line_entry_ext_v1.ex
+++ b/lib/xdr/ledger_entries/trust_line_entry_ext_v1.ex
@@ -1,0 +1,83 @@
+defmodule StellarBase.XDR.TrustLineEntryExtV1 do
+  @moduledoc """
+  Representation of Stellar `TrustLineEntryExtV1` type.
+  """
+  alias StellarBase.XDR.{Liabilities, TrustLineEntryExtV1Ext}
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(
+                 liabilities: Liabilities,
+                 trust_line_entry_ext_v1_ext: TrustLineEntryExtV1Ext
+               )
+
+  defstruct [:liabilities, :trust_line_entry_ext_v1_ext]
+
+  @type t :: %__MODULE__{
+          liabilities: Liabilities.t(),
+          trust_line_entry_ext_v1_ext: TrustLineEntryExtV1Ext.t()
+        }
+
+  @spec new(
+          liabilities :: Liabilities.t(),
+          trust_line_entry_ext_v1_ext :: TrustLineEntryExtV1Ext.t()
+        ) :: t()
+  def new(%Liabilities{} = liabilities, %TrustLineEntryExtV1Ext{} = trust_line_entry_ext_v1_ext),
+    do: %__MODULE__{
+      liabilities: liabilities,
+      trust_line_entry_ext_v1_ext: trust_line_entry_ext_v1_ext
+    }
+
+  @impl true
+  def encode_xdr(%__MODULE__{
+        liabilities: liabilities,
+        trust_line_entry_ext_v1_ext: trust_line_entry_ext_v1_ext
+      }) do
+    [liabilities: liabilities, trust_line_entry_ext_v1_ext: trust_line_entry_ext_v1_ext]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{
+        liabilities: liabilities,
+        trust_line_entry_ext_v1_ext: trust_line_entry_ext_v1_ext
+      }) do
+    [liabilities: liabilities, trust_line_entry_ext_v1_ext: trust_line_entry_ext_v1_ext]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok,
+       {%XDR.Struct{
+          components: [
+            liabilities: liabilities,
+            trust_line_entry_ext_v1_ext: trust_line_entry_ext_v1_ext
+          ]
+        }, rest}} ->
+        {:ok, {new(liabilities, trust_line_entry_ext_v1_ext), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{
+       components: [
+         liabilities: liabilities,
+         trust_line_entry_ext_v1_ext: trust_line_entry_ext_v1_ext
+       ]
+     }, rest} = XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(liabilities, trust_line_entry_ext_v1_ext), rest}
+  end
+end

--- a/lib/xdr/ledger_entries/trust_line_entry_ext_v1_ext.ex
+++ b/lib/xdr/ledger_entries/trust_line_entry_ext_v1_ext.ex
@@ -1,0 +1,64 @@
+defmodule StellarBase.XDR.TrustLineEntryExtV1Ext do
+  @moduledoc """
+  Representation of Stellar `TrustLineEntryExtV1Ext` type.
+  """
+  @behaviour XDR.Declaration
+
+  alias StellarBase.XDR.{Void, TrustLineEntryExtV2}
+
+  @arms %{0 => Void, 2 => TrustLineEntryExtV2}
+
+  @type value :: Void.t() | TrustLineEntryExtV2.t()
+
+  @type t :: %__MODULE__{value: value(), type: non_neg_integer()}
+
+  defstruct [:value, :type]
+
+  @spec new(value :: value(), type :: non_neg_integer()) :: t()
+  def new(value, type),
+    do: %__MODULE__{value: value, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{value: value, type: type}) do
+    type
+    |> XDR.Int.new()
+    |> XDR.Union.new(@arms, value)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{value: value, type: type}) do
+    type
+    |> XDR.Int.new()
+    |> XDR.Union.new(@arms, value)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  @spec decode_xdr(binary, map) ::
+          {:error, :invalid_arm | :not_binary | :not_list}
+          | {:ok, {StellarBase.XDR.TrustLineEntryExtV1Ext.t(), binary}}
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{type, value}, rest}} -> {:ok, {new(value, type), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  @spec decode_xdr!(binary, map) :: {StellarBase.XDR.TrustLineEntryExtV1Ext.t(), binary}
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{type, value}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(value, type), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    XDR.Int.new(0)
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/ledger_entries/trust_line_entry_ext_v1_ext.ex
+++ b/lib/xdr/ledger_entries/trust_line_entry_ext_v1_ext.ex
@@ -35,9 +35,6 @@ defmodule StellarBase.XDR.TrustLineEntryExtV1Ext do
   end
 
   @impl true
-  @spec decode_xdr(binary, map) ::
-          {:error, :invalid_arm | :not_binary | :not_list}
-          | {:ok, {StellarBase.XDR.TrustLineEntryExtV1Ext.t(), binary}}
   def decode_xdr(bytes, spec \\ union_spec())
 
   def decode_xdr(bytes, spec) do
@@ -48,7 +45,6 @@ defmodule StellarBase.XDR.TrustLineEntryExtV1Ext do
   end
 
   @impl true
-  @spec decode_xdr!(binary, map) :: {StellarBase.XDR.TrustLineEntryExtV1Ext.t(), binary}
   def decode_xdr!(bytes, spec \\ union_spec())
 
   def decode_xdr!(bytes, spec) do
@@ -58,7 +54,8 @@ defmodule StellarBase.XDR.TrustLineEntryExtV1Ext do
 
   @spec union_spec() :: XDR.Union.t()
   defp union_spec do
-    XDR.Int.new(0)
+    0
+    |> XDR.Int.new()
     |> XDR.Union.new(@arms)
   end
 end

--- a/lib/xdr/ledger_entries/trust_line_entry_ext_v2.ex
+++ b/lib/xdr/ledger_entries/trust_line_entry_ext_v2.ex
@@ -1,0 +1,57 @@
+defmodule StellarBase.XDR.TrustLineEntryExtV2 do
+  @moduledoc """
+  Representation of Stellar `TrustLineEntryExtV2` type.
+  """
+  alias StellarBase.XDR.{Int32, Ext}
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(liquidity_pool_use_count: Int32, ext: Ext)
+
+  @type t :: %__MODULE__{liquidity_pool_use_count: Int32.t(), ext: Ext.t()}
+
+  defstruct [:liquidity_pool_use_count, :ext]
+
+  @spec new(liquidity_pool_use_count :: Int32.t(), ext :: Ext.t()) :: t()
+  def new(%Int32{} = liquidity_pool_use_count, %Ext{} = ext),
+    do: %__MODULE__{liquidity_pool_use_count: liquidity_pool_use_count, ext: ext}
+
+  @impl true
+  def encode_xdr(%__MODULE__{liquidity_pool_use_count: liquidity_pool_use_count, ext: ext}) do
+    [liquidity_pool_use_count: liquidity_pool_use_count, ext: ext]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{liquidity_pool_use_count: liquidity_pool_use_count, ext: ext}) do
+    [liquidity_pool_use_count: liquidity_pool_use_count, ext: ext]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok,
+       {%XDR.Struct{components: [liquidity_pool_use_count: liquidity_pool_use_count, ext: ext]},
+        rest}} ->
+        {:ok, {new(liquidity_pool_use_count, ext), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [liquidity_pool_use_count: liquidity_pool_use_count, ext: ext]},
+     rest} = XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(liquidity_pool_use_count, ext), rest}
+  end
+end

--- a/test/xdr/ledger_entries/offer_entry_test.exs
+++ b/test/xdr/ledger_entries/offer_entry_test.exs
@@ -1,7 +1,7 @@
 defmodule StellarBase.XDR.OfferEntryTest do
   use ExUnit.Case
 
-  import StellarBase.Test.Utils
+  import StellarBase.Test.Utils, only: [create_account_id: 1, create_asset: 2]
 
   alias StellarBase.XDR.{Ext, Int32, Int64, OfferEntry, Price}
 

--- a/test/xdr/ledger_entries/trust_line_entry_ext_test.exs
+++ b/test/xdr/ledger_entries/trust_line_entry_ext_test.exs
@@ -1,0 +1,102 @@
+defmodule StellarBase.XDR.TrustLineEntryExtTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    TrustLineEntryExt,
+    Void,
+    TrustLineEntryExtV1,
+    Liabilities,
+    TrustLineEntryExtV1Ext,
+    TrustLineEntryExtV2,
+    Int32,
+    Int64,
+    Ext
+  }
+
+  @trust_line_entry_ext_v1_ext_types [
+    %{type: 0, value: Void.new()},
+    %{type: 2, value: TrustLineEntryExtV2.new(Int32.new(10), Ext.new())}
+  ]
+
+  @types [0, 1, 1]
+
+  describe "TrustLineEntryExt" do
+    setup do
+      buying = Int64.new(20)
+      selling = Int64.new(10)
+      liabilities = Liabilities.new(buying, selling)
+
+      trust_line_entry_ext_v1_ext_list =
+        @trust_line_entry_ext_v1_ext_types
+        |> Enum.map(fn %{type: type, value: value} -> TrustLineEntryExtV1Ext.new(value, type) end)
+
+      trust_line_entry_ext_v1_list =
+        trust_line_entry_ext_v1_ext_list
+        |> Enum.map(fn trust_line_entry_ext_v1_ext ->
+          TrustLineEntryExtV1.new(liabilities, trust_line_entry_ext_v1_ext)
+        end)
+
+      values = [Void.new()] ++ trust_line_entry_ext_v1_list
+
+      trust_line_entry_ext_list =
+        values
+        |> Enum.zip(@types)
+        |> Enum.map(fn {value, type} ->
+          TrustLineEntryExt.new(value, type)
+        end)
+
+      %{
+        types: @types,
+        values: values,
+        trust_line_entry_ext_list: trust_line_entry_ext_list,
+        binaries: [
+          <<0, 0, 0, 0>>,
+          <<0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0>>,
+          <<0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 2, 0, 0, 0, 10,
+            0, 0, 0, 0>>
+        ]
+      }
+    end
+
+    test "new/1", %{values: values, types: types} do
+      for {value, type} <- Enum.zip(values, types),
+          do: %TrustLineEntryExt{value: ^value, type: ^type} = TrustLineEntryExt.new(value, type)
+    end
+
+    test "encode_xdr/1", %{
+      trust_line_entry_ext_list: trust_line_entry_ext_list,
+      binaries: binaries
+    } do
+      for {trust_line_entry_ext, binary} <- Enum.zip(trust_line_entry_ext_list, binaries),
+          do: {:ok, ^binary} = TrustLineEntryExt.encode_xdr(trust_line_entry_ext)
+    end
+
+    test "encode_xdr!/1", %{
+      trust_line_entry_ext_list: trust_line_entry_ext_list,
+      binaries: binaries
+    } do
+      for {trust_line_entry_ext, binary} <- Enum.zip(trust_line_entry_ext_list, binaries),
+          do: ^binary = TrustLineEntryExt.encode_xdr!(trust_line_entry_ext)
+    end
+
+    test "decode_xdr/2", %{
+      trust_line_entry_ext_list: trust_line_entry_ext_list,
+      binaries: binaries
+    } do
+      for {trust_line_entry_ext, binary} <- Enum.zip(trust_line_entry_ext_list, binaries),
+          do: {:ok, {^trust_line_entry_ext, ""}} = TrustLineEntryExt.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = TrustLineEntryExt.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{
+      trust_line_entry_ext_list: trust_line_entry_ext_list,
+      binaries: binaries
+    } do
+      for {trust_line_entry_ex, binary} <- Enum.zip(trust_line_entry_ext_list, binaries),
+          do: {^trust_line_entry_ex, ^binary} = TrustLineEntryExt.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/ledger_entries/trust_line_entry_ext_v1_ext_test.exs
+++ b/test/xdr/ledger_entries/trust_line_entry_ext_v1_ext_test.exs
@@ -1,0 +1,57 @@
+defmodule StellarBase.XDR.TrustLineEntryExtV1ExtTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{TrustLineEntryExtV1Ext, TrustLineEntryExtV2, Void, Int32, Ext}
+
+  @base_data [
+    %{type: 0, value: Void.new()},
+    %{type: 2, value: TrustLineEntryExtV2.new(Int32.new(10), Ext.new())}
+  ]
+
+  @types [0, 2]
+
+  describe "TrustLineEntryExtV1Ext" do
+    setup do
+      values =
+        @base_data
+        |> Enum.map(fn %{type: type, value: value} -> TrustLineEntryExtV1Ext.new(value, type) end)
+
+      %{
+        values: values,
+        types: @types,
+        binaries: [<<0, 0, 0, 0>>, <<0, 0, 0, 2, 0, 0, 0, 10, 0, 0, 0, 0>>]
+      }
+    end
+
+    test "new/1", %{values: values, types: types} do
+      for {value, type} <- Enum.zip(values, types),
+          do:
+            %TrustLineEntryExtV1Ext{value: ^value, type: ^type} =
+              TrustLineEntryExtV1Ext.new(value, type)
+    end
+
+    test "encode_xdr/1", %{values: values, binaries: binaries} do
+      for {value, binary} <- Enum.zip(values, binaries),
+          do: {:ok, ^binary} = TrustLineEntryExtV1Ext.encode_xdr(value)
+    end
+
+    test "encode_xdr!/1", %{values: values, binaries: binaries} do
+      for {value, binary} <- Enum.zip(values, binaries),
+          do: ^binary = TrustLineEntryExtV1Ext.encode_xdr!(value)
+    end
+
+    test "decode_xdr/2", %{values: values, binaries: binaries} do
+      for {value, binary} <- Enum.zip(values, binaries),
+          do: {:ok, {^value, ""}} = TrustLineEntryExtV1Ext.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = TrustLineEntryExtV1Ext.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{values: values, binaries: binaries} do
+      for {value, binary} <- Enum.zip(values, binaries),
+          do: {^value, ^binary} = TrustLineEntryExtV1Ext.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/ledger_entries/trust_line_entry_ext_v1_test.exs
+++ b/test/xdr/ledger_entries/trust_line_entry_ext_v1_test.exs
@@ -1,0 +1,96 @@
+defmodule StellarBase.XDR.TrustLineEntryExtV1Test do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    Liabilities,
+    TrustLineEntryExtV2,
+    TrustLineEntryExtV1Ext,
+    TrustLineEntryExtV1,
+    Void,
+    Ext,
+    Int32,
+    Int64
+  }
+
+  @base_data [
+    %{type: 0, value: Void.new()},
+    %{type: 2, value: TrustLineEntryExtV2.new(Int32.new(10), Ext.new())}
+  ]
+
+  describe "TrustLineEntryExtV1" do
+    setup do
+      buying = Int64.new(20)
+      selling = Int64.new(10)
+
+      trust_line_entry_ext_v1_ext_list =
+        @base_data
+        |> Enum.map(fn %{type: type, value: value} -> TrustLineEntryExtV1Ext.new(value, type) end)
+
+      liabilities = Liabilities.new(buying, selling)
+
+      %{
+        liabilities: liabilities,
+        trust_line_entry_ext_v1_ext_list: trust_line_entry_ext_v1_ext_list,
+        trust_line_entry_ext_v1_list:
+          Enum.map(trust_line_entry_ext_v1_ext_list, fn trust_line_entry_ext_v1_ext ->
+            TrustLineEntryExtV1.new(liabilities, trust_line_entry_ext_v1_ext)
+          end),
+        binaries: [
+          <<0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0>>,
+          <<0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 2, 0, 0, 0, 10, 0, 0, 0,
+            0>>
+        ]
+      }
+    end
+
+    test "new/1", %{
+      liabilities: liabilities,
+      trust_line_entry_ext_v1_ext_list: trust_line_entry_ext_v1_ext_list
+    } do
+      for trust_line_entry_ext_v1_ext <- trust_line_entry_ext_v1_ext_list,
+          do:
+            %TrustLineEntryExtV1{
+              liabilities: ^liabilities,
+              trust_line_entry_ext_v1_ext: ^trust_line_entry_ext_v1_ext
+            } = TrustLineEntryExtV1.new(liabilities, trust_line_entry_ext_v1_ext)
+    end
+
+    test "encode_xdr/1", %{
+      trust_line_entry_ext_v1_list: trust_line_entry_ext_v1_list,
+      binaries: binaries
+    } do
+      for {trust_line_entry_ext_v1, binary} <- Enum.zip(trust_line_entry_ext_v1_list, binaries),
+          do: {:ok, ^binary} = TrustLineEntryExtV1.encode_xdr(trust_line_entry_ext_v1)
+    end
+
+    test "encode_xdr!/1", %{
+      trust_line_entry_ext_v1_list: trust_line_entry_ext_v1_list,
+      binaries: binaries
+    } do
+      for {trust_line_entry_ext_v1, binary} <- Enum.zip(trust_line_entry_ext_v1_list, binaries),
+          do: ^binary = TrustLineEntryExtV1.encode_xdr!(trust_line_entry_ext_v1)
+    end
+
+    test "decode_xdr/2", %{
+      trust_line_entry_ext_v1_list: trust_line_entry_ext_v1_list,
+      binaries: binaries
+    } do
+      for {trust_line_entry_ext_v1, binary} <- Enum.zip(trust_line_entry_ext_v1_list, binaries),
+          do: {:ok, {^trust_line_entry_ext_v1, ""}} = TrustLineEntryExtV1.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = TrustLineEntryExtV1.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{
+      trust_line_entry_ext_v1_list: trust_line_entry_ext_v1_list,
+      binaries: binaries
+    } do
+      for {trust_line_entry_ext_v1, binary} <- Enum.zip(trust_line_entry_ext_v1_list, binaries),
+          do:
+            {^trust_line_entry_ext_v1, ^binary} =
+              TrustLineEntryExtV1.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/ledger_entries/trust_line_entry_ext_v2_test.exs
+++ b/test/xdr/ledger_entries/trust_line_entry_ext_v2_test.exs
@@ -1,0 +1,44 @@
+defmodule StellarBase.XDR.TrustLineEntryExtV2Test do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{Int32, Ext, TrustLineEntryExtV2}
+
+  describe "TrustLineEntryExtV2" do
+    setup do
+      liquidity_pool_use_count = Int32.new(10)
+      ext = Ext.new()
+
+      %{
+        liquidity_pool_use_count: liquidity_pool_use_count,
+        ext: ext,
+        trust_line_entry_ext: TrustLineEntryExtV2.new(liquidity_pool_use_count, ext),
+        binary: <<0, 0, 0, 10, 0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{liquidity_pool_use_count: liquidity_pool_use_count, ext: ext} do
+      %TrustLineEntryExtV2{liquidity_pool_use_count: ^liquidity_pool_use_count, ext: ^ext} =
+        TrustLineEntryExtV2.new(liquidity_pool_use_count, ext)
+    end
+
+    test "encode_xdr/1", %{trust_line_entry_ext: trust_line_entry_ext, binary: binary} do
+      {:ok, ^binary} = TrustLineEntryExtV2.encode_xdr(trust_line_entry_ext)
+    end
+
+    test "encode_xdr!/1", %{trust_line_entry_ext: trust_line_entry_ext, binary: binary} do
+      ^binary = TrustLineEntryExtV2.encode_xdr!(trust_line_entry_ext)
+    end
+
+    test "decode_xdr/2", %{trust_line_entry_ext: trust_line_entry_ext, binary: binary} do
+      {:ok, {^trust_line_entry_ext, ""}} = TrustLineEntryExtV2.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = TrustLineEntryExtV2.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{trust_line_entry_ext: trust_line_entry_ext, binary: binary} do
+      {^trust_line_entry_ext, ^binary} = TrustLineEntryExtV2.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/ledger_entries/trust_line_entry_test.exs
+++ b/test/xdr/ledger_entries/trust_line_entry_test.exs
@@ -1,0 +1,94 @@
+defmodule StellarBase.XDR.TrustLineEntryTest do
+  use ExUnit.Case
+
+  import StellarBase.Test.Utils, only: [create_account_id: 1]
+
+  alias StellarBase.XDR.{
+    TrustLineEntry,
+    AssetType,
+    AlphaNum4,
+    AssetCode4,
+    Ext,
+    UInt32,
+    Int64,
+    TrustLineAsset
+  }
+
+  describe "TrustLineEntry" do
+    setup do
+      account_id = create_account_id("GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY")
+
+      issuer = create_account_id("GBZNLMUQMIN3VGUJISKZU7GNY3O3XLMYEHJCKCSMDHKLGSMKALRXOEZD")
+
+      asset_type = AssetType.new(:ASSET_TYPE_CREDIT_ALPHANUM4)
+
+      asset =
+        "BTCN"
+        |> AssetCode4.new()
+        |> AlphaNum4.new(issuer)
+        |> TrustLineAsset.new(asset_type)
+
+      balance = Int64.new(5_000_000)
+
+      limit = Int64.new(6_000_000)
+
+      flags = UInt32.new(1)
+
+      ext = Ext.new()
+
+      %{
+        account_id: account_id,
+        asset: asset,
+        balance: balance,
+        limit: limit,
+        flags: flags,
+        ext: ext,
+        trust_line_entry: TrustLineEntry.new(account_id, asset, balance, limit, flags, ext),
+        binary:
+          <<0, 0, 0, 0, 155, 142, 186, 248, 150, 56, 85, 29, 207, 158, 164, 247, 67, 32, 113, 16,
+            107, 135, 171, 14, 45, 179, 214, 155, 117, 165, 56, 34, 114, 247, 89, 216, 0, 0, 0, 1,
+            66, 84, 67, 78, 0, 0, 0, 0, 114, 213, 178, 144, 98, 27, 186, 154, 137, 68, 149, 154,
+            124, 205, 198, 221, 187, 173, 152, 33, 210, 37, 10, 76, 25, 212, 179, 73, 138, 2, 227,
+            119, 0, 0, 0, 0, 0, 76, 75, 64, 0, 0, 0, 0, 0, 91, 141, 128, 0, 0, 0, 1, 0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{
+      account_id: account_id,
+      asset: asset,
+      balance: balance,
+      limit: limit,
+      flags: flags,
+      ext: ext
+    } do
+      %TrustLineEntry{
+        account_id: ^account_id,
+        asset: ^asset,
+        balance: ^balance,
+        limit: ^limit,
+        flags: ^flags,
+        ext: ^ext
+      } = TrustLineEntry.new(account_id, asset, balance, limit, flags, ext)
+    end
+
+    test "encode_xdr/1", %{trust_line_entry: trust_line_entry, binary: binary} do
+      {:ok, ^binary} = TrustLineEntry.encode_xdr(trust_line_entry)
+    end
+
+    test "encode_xdr!/1", %{trust_line_entry: trust_line_entry, binary: binary} do
+      ^binary = TrustLineEntry.encode_xdr!(trust_line_entry)
+    end
+
+    test "decode_xdr/2", %{trust_line_entry: trust_line_entry, binary: binary} do
+      {:ok, {^trust_line_entry, ""}} = TrustLineEntry.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = TrustLineEntry.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{trust_line_entry: trust_line_entry, binary: binary} do
+      {^trust_line_entry, ^binary} = TrustLineEntry.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/ledger_entries/trust_line_entry_test.exs
+++ b/test/xdr/ledger_entries/trust_line_entry_test.exs
@@ -8,11 +8,25 @@ defmodule StellarBase.XDR.TrustLineEntryTest do
     AssetType,
     AlphaNum4,
     AssetCode4,
-    Ext,
+    TrustLineEntryExt,
     UInt32,
     Int64,
-    TrustLineAsset
+    TrustLineAsset,
+    Void,
+    Liabilities,
+    TrustLineEntryExtV1,
+    TrustLineEntryExtV2,
+    Int32,
+    Ext,
+    TrustLineEntryExtV1Ext
   }
+
+  @trust_line_entry_ext_v1_ext_types [
+    %{type: 0, value: Void.new()},
+    %{type: 2, value: TrustLineEntryExtV2.new(Int32.new(10), Ext.new())}
+  ]
+
+  @types [0, 1, 1]
 
   describe "TrustLineEntry" do
     setup do
@@ -34,7 +48,28 @@ defmodule StellarBase.XDR.TrustLineEntryTest do
 
       flags = UInt32.new(1)
 
-      ext = Ext.new()
+      buying = Int64.new(20)
+      selling = Int64.new(10)
+      liabilities = Liabilities.new(buying, selling)
+
+      trust_line_entry_ext_v1_ext_list =
+        @trust_line_entry_ext_v1_ext_types
+        |> Enum.map(fn %{type: type, value: value} -> TrustLineEntryExtV1Ext.new(value, type) end)
+
+      trust_line_entry_ext_v1_list =
+        trust_line_entry_ext_v1_ext_list
+        |> Enum.map(fn trust_line_entry_ext_v1_ext ->
+          TrustLineEntryExtV1.new(liabilities, trust_line_entry_ext_v1_ext)
+        end)
+
+      values = [Void.new()] ++ trust_line_entry_ext_v1_list
+
+      trust_line_entry_ext_list =
+        values
+        |> Enum.zip(@types)
+        |> Enum.map(fn {value, type} ->
+          TrustLineEntryExt.new(value, type)
+        end)
 
       %{
         account_id: account_id,
@@ -42,14 +77,25 @@ defmodule StellarBase.XDR.TrustLineEntryTest do
         balance: balance,
         limit: limit,
         flags: flags,
-        ext: ext,
-        trust_line_entry: TrustLineEntry.new(account_id, asset, balance, limit, flags, ext),
-        binary:
+        trust_line_entry_ext_list: trust_line_entry_ext_list,
+        trust_line_entry_list:
+          trust_line_entry_ext_list
+          |> Enum.map(fn trust_line_entry_ext ->
+            TrustLineEntry.new(account_id, asset, balance, limit, flags, trust_line_entry_ext)
+          end),
+        binaries: [
           <<0, 0, 0, 0, 155, 142, 186, 248, 150, 56, 85, 29, 207, 158, 164, 247, 67, 32, 113, 16,
             107, 135, 171, 14, 45, 179, 214, 155, 117, 165, 56, 34, 114, 247, 89, 216, 0, 0, 0, 1,
             66, 84, 67, 78, 0, 0, 0, 0, 114, 213, 178, 144, 98, 27, 186, 154, 137, 68, 149, 154,
             124, 205, 198, 221, 187, 173, 152, 33, 210, 37, 10, 76, 25, 212, 179, 73, 138, 2, 227,
-            119, 0, 0, 0, 0, 0, 76, 75, 64, 0, 0, 0, 0, 0, 91, 141, 128, 0, 0, 0, 1, 0, 0, 0, 0>>
+            119, 0, 0, 0, 0, 0, 76, 75, 64, 0, 0, 0, 0, 0, 91, 141, 128, 0, 0, 0, 1, 0, 0, 0, 0>>,
+          <<0, 0, 0, 0, 155, 142, 186, 248, 150, 56, 85, 29, 207, 158, 164, 247, 67, 32, 113, 16,
+            107, 135, 171, 14, 45, 179, 214, 155, 117, 165, 56, 34, 114, 247, 89, 216, 0, 0, 0, 1,
+            66, 84, 67, 78, 0, 0, 0, 0, 114, 213, 178, 144, 98, 27, 186, 154, 137, 68, 149, 154,
+            124, 205, 198, 221, 187, 173, 152, 33, 210, 37, 10, 76, 25, 212, 179, 73, 138, 2, 227,
+            119, 0, 0, 0, 0, 0, 76, 75, 64, 0, 0, 0, 0, 0, 91, 141, 128, 0, 0, 0, 1, 0, 0, 0, 1,
+            0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0>>
+        ]
       }
     end
 
@@ -59,36 +105,42 @@ defmodule StellarBase.XDR.TrustLineEntryTest do
       balance: balance,
       limit: limit,
       flags: flags,
-      ext: ext
+      trust_line_entry_ext_list: trust_line_entry_ext_list
     } do
-      %TrustLineEntry{
-        account_id: ^account_id,
-        asset: ^asset,
-        balance: ^balance,
-        limit: ^limit,
-        flags: ^flags,
-        ext: ^ext
-      } = TrustLineEntry.new(account_id, asset, balance, limit, flags, ext)
+      for trust_line_entry_ext <- trust_line_entry_ext_list,
+          do:
+            %TrustLineEntry{
+              account_id: ^account_id,
+              asset: ^asset,
+              balance: ^balance,
+              limit: ^limit,
+              flags: ^flags,
+              trust_line_entry_ext: ^trust_line_entry_ext
+            } = TrustLineEntry.new(account_id, asset, balance, limit, flags, trust_line_entry_ext)
     end
 
-    test "encode_xdr/1", %{trust_line_entry: trust_line_entry, binary: binary} do
-      {:ok, ^binary} = TrustLineEntry.encode_xdr(trust_line_entry)
+    test "encode_xdr/1", %{trust_line_entry_list: trust_line_entry_list, binaries: binaries} do
+      for {trust_line_entry, binary} <- Enum.zip(trust_line_entry_list, binaries),
+          do: {:ok, ^binary} = TrustLineEntry.encode_xdr(trust_line_entry)
     end
 
-    test "encode_xdr!/1", %{trust_line_entry: trust_line_entry, binary: binary} do
-      ^binary = TrustLineEntry.encode_xdr!(trust_line_entry)
+    test "encode_xdr!/1", %{trust_line_entry_list: trust_line_entry_list, binaries: binaries} do
+      for {trust_line_entry, binary} <- Enum.zip(trust_line_entry_list, binaries),
+          do: ^binary = TrustLineEntry.encode_xdr!(trust_line_entry)
     end
 
-    test "decode_xdr/2", %{trust_line_entry: trust_line_entry, binary: binary} do
-      {:ok, {^trust_line_entry, ""}} = TrustLineEntry.decode_xdr(binary)
+    test "decode_xdr/2", %{trust_line_entry_list: trust_line_entry_list, binaries: binaries} do
+      for {trust_line_entry, binary} <- Enum.zip(trust_line_entry_list, binaries),
+          do: {:ok, {^trust_line_entry, ""}} = TrustLineEntry.decode_xdr(binary)
     end
 
     test "decode_xdr/2 with an invalid binary" do
       {:error, :not_binary} = TrustLineEntry.decode_xdr(123)
     end
 
-    test "decode_xdr!/2", %{trust_line_entry: trust_line_entry, binary: binary} do
-      {^trust_line_entry, ^binary} = TrustLineEntry.decode_xdr!(binary <> binary)
+    test "decode_xdr!/2", %{trust_line_entry_list: trust_line_entry_list, binaries: binaries} do
+      for {trust_line_entry, binary} <- Enum.zip(trust_line_entry_list, binaries),
+          do: {^trust_line_entry, ^binary} = TrustLineEntry.decode_xdr!(binary <> binary)
     end
   end
 end


### PR DESCRIPTION
# Issue 

#135
Add TrustLineEntry asset

**Changes**
Was added the modules for XDR type TrustLineEntry, TrustLineEntryExt, TrustLineEntryExtV1, TrustLineEntryExtV1Ext, and TrustLineEntryExtV2 with the respective tests files.

**Screenshot**

<img width="1016" alt="Screen Shot 2022-02-20 at 8 48 44 PM" src="https://user-images.githubusercontent.com/2568221/154875923-3fbf8cf1-bcb8-459e-b692-712141fbde75.png">

