### PR TITLE
add security policy to repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting Security Issues
+
+To report a security issue, please email [oss@kommit.co](mailto:oss@kommit.co) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+If the issue is confirmed as a vulnerability, we will open a Security Advisory and acknowledge your contributions as part of it.


### PR DESCRIPTION
Closes #136.

## Objective
Create the security policy in the repository to ensure compliance with policies within the organization.

## Description
Adds the SECURITY.md file to display the security policy in the repository. Please refer to [policy here](https://github.com/kommitters/editorjs-inline-image/security/policy).