### PR TITLE
Bump ossf/scorecard-action to v2.0.6

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972 # tag=v2.0.3
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # tag=v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Since the scorecard workflow [failed](https://github.com/kommitters/stellar_base/actions/runs/3364710697/jobs/5579371353), we need to bump `ossf/scorecard-action` to v2.0.6

Context: https://github.com/ossf/scorecard-action/issues/997