### PR TITLE
Add Contract XDR types - Part 2

### DIFF
--- a/lib/xdr/contract/int128_parts.ex
+++ b/lib/xdr/contract/int128_parts.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.Int128Parts do
   @moduledoc """
   Representation of Stellar `Int128Parts` type.
   """
+
   alias StellarBase.XDR.{UInt64}
 
   @behaviour XDR.Declaration
@@ -13,8 +14,7 @@ defmodule StellarBase.XDR.Int128Parts do
   defstruct [:lo, :hi]
 
   @spec new(lo :: UInt64.t(), hi :: UInt64.t()) :: t()
-  def new(%UInt64{} = lo, %UInt64{} = hi),
-    do: %__MODULE__{lo: lo, hi: hi}
+  def new(%UInt64{} = lo, %UInt64{} = hi), do: %__MODULE__{lo: lo, hi: hi}
 
   @impl true
   def encode_xdr(%__MODULE__{lo: lo, hi: hi}) do

--- a/lib/xdr/contract/int128_parts.ex
+++ b/lib/xdr/contract/int128_parts.ex
@@ -3,7 +3,7 @@ defmodule StellarBase.XDR.Int128Parts do
   Representation of Stellar `Int128Parts` type.
   """
 
-  alias StellarBase.XDR.{UInt64}
+  alias StellarBase.XDR.UInt64
 
   @behaviour XDR.Declaration
 

--- a/lib/xdr/contract/int128_parts.ex
+++ b/lib/xdr/contract/int128_parts.ex
@@ -1,0 +1,54 @@
+defmodule StellarBase.XDR.Int128Parts do
+  @moduledoc """
+  Representation of Stellar `Int128Parts` type.
+  """
+  alias StellarBase.XDR.{UInt64}
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(lo: UInt64, hi: UInt64)
+
+  @type t :: %__MODULE__{lo: UInt64.t(), hi: UInt64.t()}
+
+  defstruct [:lo, :hi]
+
+  @spec new(lo :: UInt64.t(), hi :: UInt64.t()) :: t()
+  def new(%UInt64{} = lo, %UInt64{} = hi),
+    do: %__MODULE__{lo: lo, hi: hi}
+
+  @impl true
+  def encode_xdr(%__MODULE__{lo: lo, hi: hi}) do
+    [lo: lo, hi: hi]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{lo: lo, hi: hi}) do
+    [lo: lo, hi: hi]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [lo: lo, hi: hi]}, rest}} ->
+        {:ok, {new(lo, hi), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [lo: lo, hi: hi]}, rest} = XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(lo, hi), rest}
+  end
+end

--- a/lib/xdr/contract/optional_sc_object.ex
+++ b/lib/xdr/contract/optional_sc_object.ex
@@ -1,0 +1,59 @@
+defmodule StellarBase.XDR.OptionalSCObject do
+  @moduledoc """
+  Representation of Stellar `OptionalSCObject` type.
+  """
+  alias StellarBase.XDR.SCObject
+
+  @behaviour XDR.Declaration
+
+  @optional_spec XDR.Optional.new(SCObject)
+
+  @type sc_object :: SCObject.t() | nil
+
+  @type t :: %__MODULE__{sc_object: sc_object()}
+
+  defstruct [:sc_object]
+
+  @spec new(sc_object :: sc_object()) :: t()
+  def new(sc_object \\ nil), do: %__MODULE__{sc_object: sc_object}
+
+  @impl true
+  def encode_xdr(%__MODULE__{sc_object: sc_object}) do
+    sc_object
+    |> XDR.Optional.new()
+    |> XDR.Optional.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{sc_object: sc_object}) do
+    sc_object
+    |> XDR.Optional.new()
+    |> XDR.Optional.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, optional_spec \\ @optional_spec)
+
+  def decode_xdr(bytes, optional_spec) do
+    case XDR.Optional.decode_xdr(bytes, optional_spec) do
+      {:ok, {%XDR.Optional{type: sc_object}, rest}} ->
+        {:ok, {new(sc_object), rest}}
+
+      {:ok, {nil, rest}} ->
+        {:ok, {new(), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, optional_spec \\ @optional_spec)
+
+  def decode_xdr!(bytes, optional_spec) do
+    case XDR.Optional.decode_xdr!(bytes, optional_spec) do
+      {%XDR.Optional{type: sc_object}, rest} -> {new(sc_object), rest}
+      {nil, rest} -> {new(), rest}
+    end
+  end
+end

--- a/lib/xdr/contract/optional_sc_object.ex
+++ b/lib/xdr/contract/optional_sc_object.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.OptionalSCObject do
   @moduledoc """
   Representation of Stellar `OptionalSCObject` type.
   """
+
   alias StellarBase.XDR.SCObject
 
   @behaviour XDR.Declaration

--- a/lib/xdr/contract/sc_address.ex
+++ b/lib/xdr/contract/sc_address.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCAddress do
   @moduledoc """
   Representation of Stellar `SCAddress` type.
   """
+
   alias StellarBase.XDR.{AccountID, Hash, SCAddressType}
 
   @behaviour XDR.Declaration

--- a/lib/xdr/contract/sc_address.ex
+++ b/lib/xdr/contract/sc_address.ex
@@ -1,0 +1,62 @@
+defmodule StellarBase.XDR.SCAddress do
+  @moduledoc """
+  Representation of Stellar `SCAddress` type.
+  """
+  alias StellarBase.XDR.{AccountID, Hash, SCAddressType}
+
+  @behaviour XDR.Declaration
+
+  @arms [
+    SC_ADDRESS_TYPE_ACCOUNT: AccountID,
+    SC_ADDRESS_TYPE_CONTRACT: Hash
+  ]
+
+  @type sc_address :: AccountID.t() | Hash.t()
+
+  @type t :: %__MODULE__{sc_address: sc_address(), type: SCAddressType.t()}
+
+  defstruct [:sc_address, :type]
+
+  @spec new(sc_address :: sc_address(), type :: SCAddressType.t()) :: t()
+  def new(sc_address, %SCAddressType{} = type),
+    do: %__MODULE__{sc_address: sc_address, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{sc_address: sc_address, type: type}) do
+    type
+    |> XDR.Union.new(@arms, sc_address)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{sc_address: sc_address, type: type}) do
+    type
+    |> XDR.Union.new(@arms, sc_address)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{type, sc_address}, rest}} -> {:ok, {new(sc_address, type), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{type, sc_address}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(sc_address, type), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> SCAddressType.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/contract/sc_address_type.ex
+++ b/lib/xdr/contract/sc_address_type.ex
@@ -1,0 +1,52 @@
+defmodule StellarBase.XDR.SCAddressType do
+  @moduledoc """
+  Representation of Stellar `SCAddressType` type.
+  """
+  @behaviour XDR.Declaration
+
+  @declarations [
+    SC_ADDRESS_TYPE_ACCOUNT: 0,
+    SC_ADDRESS_TYPE_CONTRACT: 1
+  ]
+
+  @enum_spec %XDR.Enum{declarations: @declarations, identifier: nil}
+
+  @type t :: %__MODULE__{identifier: atom()}
+
+  defstruct [:identifier]
+
+  @spec new(code :: atom()) :: t()
+  def new(code), do: %__MODULE__{identifier: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @enum_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Enum.decode_xdr(bytes, spec) do
+      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @enum_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(code), rest}
+  end
+end

--- a/lib/xdr/contract/sc_address_type.ex
+++ b/lib/xdr/contract/sc_address_type.ex
@@ -16,20 +16,20 @@ defmodule StellarBase.XDR.SCAddressType do
 
   defstruct [:identifier]
 
-  @spec new(code :: atom()) :: t()
-  def new(code), do: %__MODULE__{identifier: code}
+  @spec new(type :: atom()) :: t()
+  def new(type), do: %__MODULE__{identifier: type}
 
   @impl true
-  def encode_xdr(%__MODULE__{identifier: code}) do
+  def encode_xdr(%__MODULE__{identifier: type}) do
     @declarations
-    |> XDR.Enum.new(code)
+    |> XDR.Enum.new(type)
     |> XDR.Enum.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{identifier: code}) do
+  def encode_xdr!(%__MODULE__{identifier: type}) do
     @declarations
-    |> XDR.Enum.new(code)
+    |> XDR.Enum.new(type)
     |> XDR.Enum.encode_xdr!()
   end
 
@@ -38,7 +38,7 @@ defmodule StellarBase.XDR.SCAddressType do
 
   def decode_xdr(bytes, spec) do
     case XDR.Enum.decode_xdr(bytes, spec) do
-      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      {:ok, {%XDR.Enum{identifier: type}, rest}} -> {:ok, {new(type), rest}}
       error -> error
     end
   end
@@ -47,7 +47,7 @@ defmodule StellarBase.XDR.SCAddressType do
   def decode_xdr!(bytes, spec \\ @enum_spec)
 
   def decode_xdr!(bytes, spec) do
-    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
-    {new(code), rest}
+    {%XDR.Enum{identifier: type}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(type), rest}
   end
 end

--- a/lib/xdr/contract/sc_address_type.ex
+++ b/lib/xdr/contract/sc_address_type.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCAddressType do
   @moduledoc """
   Representation of Stellar `SCAddressType` type.
   """
+
   @behaviour XDR.Declaration
 
   @declarations [

--- a/lib/xdr/contract/sc_contract_code.ex
+++ b/lib/xdr/contract/sc_contract_code.ex
@@ -1,0 +1,62 @@
+defmodule StellarBase.XDR.SCContractCode do
+  @moduledoc """
+  Representation of Stellar `SCContractCode` type.
+  """
+  alias StellarBase.XDR.{Hash, SCContractCodeType, Void}
+
+  @behaviour XDR.Declaration
+
+  @arms [
+    SCCONTRACT_CODE_WASM_REF: Hash,
+    SCCONTRACT_CODE_TOKEN: Void
+  ]
+
+  @type contract_code :: Hash.t() | Void.t()
+
+  @type t :: %__MODULE__{contract_code: contract_code(), type: SCContractCodeType.t()}
+
+  defstruct [:contract_code, :type]
+
+  @spec new(contract_code :: contract_code(), type :: SCContractCodeType.t()) :: t()
+  def new(contract_code, %SCContractCodeType{} = type),
+    do: %__MODULE__{contract_code: contract_code, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{contract_code: contract_code, type: type}) do
+    type
+    |> XDR.Union.new(@arms, contract_code)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{contract_code: contract_code, type: type}) do
+    type
+    |> XDR.Union.new(@arms, contract_code)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{type, contract_code}, rest}} -> {:ok, {new(contract_code, type), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{type, contract_code}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(contract_code, type), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> SCContractCodeType.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/contract/sc_contract_code.ex
+++ b/lib/xdr/contract/sc_contract_code.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCContractCode do
   @moduledoc """
   Representation of Stellar `SCContractCode` type.
   """
+
   alias StellarBase.XDR.{Hash, SCContractCodeType, Void}
 
   @behaviour XDR.Declaration

--- a/lib/xdr/contract/sc_contract_code_type.ex
+++ b/lib/xdr/contract/sc_contract_code_type.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCContractCodeType do
   @moduledoc """
   Representation of Stellar `SCContractCodeType` type.
   """
+
   @behaviour XDR.Declaration
 
   @declarations [

--- a/lib/xdr/contract/sc_contract_code_type.ex
+++ b/lib/xdr/contract/sc_contract_code_type.ex
@@ -1,0 +1,52 @@
+defmodule StellarBase.XDR.SCContractCodeType do
+  @moduledoc """
+  Representation of Stellar `SCContractCodeType` type.
+  """
+  @behaviour XDR.Declaration
+
+  @declarations [
+    SCCONTRACT_CODE_WASM_REF: 0,
+    SCCONTRACT_CODE_TOKEN: 1
+  ]
+
+  @enum_spec %XDR.Enum{declarations: @declarations, identifier: nil}
+
+  @type t :: %__MODULE__{identifier: atom()}
+
+  defstruct [:identifier]
+
+  @spec new(code :: atom()) :: t()
+  def new(code), do: %__MODULE__{identifier: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @enum_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Enum.decode_xdr(bytes, spec) do
+      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @enum_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(code), rest}
+  end
+end

--- a/lib/xdr/contract/sc_contract_code_type.ex
+++ b/lib/xdr/contract/sc_contract_code_type.ex
@@ -16,20 +16,20 @@ defmodule StellarBase.XDR.SCContractCodeType do
 
   defstruct [:identifier]
 
-  @spec new(code :: atom()) :: t()
-  def new(code), do: %__MODULE__{identifier: code}
+  @spec new(type :: atom()) :: t()
+  def new(type), do: %__MODULE__{identifier: type}
 
   @impl true
-  def encode_xdr(%__MODULE__{identifier: code}) do
+  def encode_xdr(%__MODULE__{identifier: type}) do
     @declarations
-    |> XDR.Enum.new(code)
+    |> XDR.Enum.new(type)
     |> XDR.Enum.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{identifier: code}) do
+  def encode_xdr!(%__MODULE__{identifier: type}) do
     @declarations
-    |> XDR.Enum.new(code)
+    |> XDR.Enum.new(type)
     |> XDR.Enum.encode_xdr!()
   end
 
@@ -38,7 +38,7 @@ defmodule StellarBase.XDR.SCContractCodeType do
 
   def decode_xdr(bytes, spec) do
     case XDR.Enum.decode_xdr(bytes, spec) do
-      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      {:ok, {%XDR.Enum{identifier: type}, rest}} -> {:ok, {new(type), rest}}
       error -> error
     end
   end
@@ -47,7 +47,7 @@ defmodule StellarBase.XDR.SCContractCodeType do
   def decode_xdr!(bytes, spec \\ @enum_spec)
 
   def decode_xdr!(bytes, spec) do
-    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
-    {new(code), rest}
+    {%XDR.Enum{identifier: type}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(type), rest}
   end
 end

--- a/lib/xdr/contract/sc_map.ex
+++ b/lib/xdr/contract/sc_map.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCMap do
   @moduledoc """
   Representation of a Stellar `SCMap` list.
   """
+
   alias StellarBase.XDR.SCMapEntry
 
   @behaviour XDR.Declaration

--- a/lib/xdr/contract/sc_map.ex
+++ b/lib/xdr/contract/sc_map.ex
@@ -1,6 +1,6 @@
 defmodule StellarBase.XDR.SCMap do
   @moduledoc """
-  Representation of a Stellar `Claimants` list.
+  Representation of a Stellar `SCMap` list.
   """
   alias StellarBase.XDR.SCMapEntry
 
@@ -12,23 +12,23 @@ defmodule StellarBase.XDR.SCMap do
 
   @array_spec %{type: @array_type, max_length: @max_length}
 
-  @type t :: %__MODULE__{claimants: list(SCMapEntry.t())}
+  @type t :: %__MODULE__{scmap_entries: list(SCMapEntry.t())}
 
-  defstruct [:claimants]
+  defstruct [:scmap_entries]
 
-  @spec new(claimants :: list(SCMapEntry.t())) :: t()
-  def new(claimants), do: %__MODULE__{claimants: claimants}
+  @spec new(scmap_entries :: list(SCMapEntry.t())) :: t()
+  def new(scmap_entries), do: %__MODULE__{scmap_entries: scmap_entries}
 
   @impl true
-  def encode_xdr(%__MODULE__{claimants: claimants}) do
-    claimants
+  def encode_xdr(%__MODULE__{scmap_entries: scmap_entries}) do
+    scmap_entries
     |> XDR.VariableArray.new(@array_type, @max_length)
     |> XDR.VariableArray.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{claimants: claimants}) do
-    claimants
+  def encode_xdr!(%__MODULE__{scmap_entries: scmap_entries}) do
+    scmap_entries
     |> XDR.VariableArray.new(@array_type, @max_length)
     |> XDR.VariableArray.encode_xdr!()
   end
@@ -38,7 +38,7 @@ defmodule StellarBase.XDR.SCMap do
 
   def decode_xdr(bytes, spec) do
     case XDR.VariableArray.decode_xdr(bytes, spec) do
-      {:ok, {claimants, rest}} -> {:ok, {new(claimants), rest}}
+      {:ok, {scmap_entries, rest}} -> {:ok, {new(scmap_entries), rest}}
       error -> error
     end
   end
@@ -47,7 +47,7 @@ defmodule StellarBase.XDR.SCMap do
   def decode_xdr!(bytes, spec \\ @array_spec)
 
   def decode_xdr!(bytes, spec) do
-    {claimants, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
-    {new(claimants), rest}
+    {scmap_entries, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(scmap_entries), rest}
   end
 end

--- a/lib/xdr/contract/sc_map.ex
+++ b/lib/xdr/contract/sc_map.ex
@@ -1,0 +1,53 @@
+defmodule StellarBase.XDR.SCMap do
+  @moduledoc """
+  Representation of a Stellar `Claimants` list.
+  """
+  alias StellarBase.XDR.SCMapEntry
+
+  @behaviour XDR.Declaration
+
+  @max_length 256_000
+
+  @array_type SCMapEntry
+
+  @array_spec %{type: @array_type, max_length: @max_length}
+
+  @type t :: %__MODULE__{claimants: list(SCMapEntry.t())}
+
+  defstruct [:claimants]
+
+  @spec new(claimants :: list(SCMapEntry.t())) :: t()
+  def new(claimants), do: %__MODULE__{claimants: claimants}
+
+  @impl true
+  def encode_xdr(%__MODULE__{claimants: claimants}) do
+    claimants
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{claimants: claimants}) do
+    claimants
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @array_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.VariableArray.decode_xdr(bytes, spec) do
+      {:ok, {claimants, rest}} -> {:ok, {new(claimants), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @array_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {claimants, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(claimants), rest}
+  end
+end

--- a/lib/xdr/contract/sc_map_entry.ex
+++ b/lib/xdr/contract/sc_map_entry.ex
@@ -1,0 +1,54 @@
+defmodule StellarBase.XDR.SCMapEntry do
+  @moduledoc """
+  Representation of Stellar `SCMapEntry` type.
+  """
+  alias StellarBase.XDR.{SCVal}
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(key: SCVal, val: SCVal)
+
+  @type t :: %__MODULE__{key: SCVal.t(), val: SCVal.t()}
+
+  defstruct [:key, :val]
+
+  @spec new(key :: SCVal.t(), val :: SCVal.t()) :: t()
+  def new(%SCVal{} = key, %SCVal{} = val),
+    do: %__MODULE__{key: key, val: val}
+
+  @impl true
+  def encode_xdr(%__MODULE__{key: key, val: val}) do
+    [key: key, val: val]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{key: key, val: val}) do
+    [key: key, val: val]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [key: key, val: val]}, rest}} ->
+        {:ok, {new(key, val), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [key: key, val: val]}, rest} = XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(key, val), rest}
+  end
+end

--- a/lib/xdr/contract/sc_map_entry.ex
+++ b/lib/xdr/contract/sc_map_entry.ex
@@ -3,7 +3,7 @@ defmodule StellarBase.XDR.SCMapEntry do
   Representation of Stellar `SCMapEntry` type.
   """
 
-  alias StellarBase.XDR.{SCVal}
+  alias StellarBase.XDR.SCVal
 
   @behaviour XDR.Declaration
 

--- a/lib/xdr/contract/sc_map_entry.ex
+++ b/lib/xdr/contract/sc_map_entry.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCMapEntry do
   @moduledoc """
   Representation of Stellar `SCMapEntry` type.
   """
+
   alias StellarBase.XDR.{SCVal}
 
   @behaviour XDR.Declaration
@@ -13,8 +14,7 @@ defmodule StellarBase.XDR.SCMapEntry do
   defstruct [:key, :val]
 
   @spec new(key :: SCVal.t(), val :: SCVal.t()) :: t()
-  def new(%SCVal{} = key, %SCVal{} = val),
-    do: %__MODULE__{key: key, val: val}
+  def new(%SCVal{} = key, %SCVal{} = val), do: %__MODULE__{key: key, val: val}
 
   @impl true
   def encode_xdr(%__MODULE__{key: key, val: val}) do

--- a/lib/xdr/contract/sc_object.ex
+++ b/lib/xdr/contract/sc_object.ex
@@ -1,0 +1,62 @@
+defmodule StellarBase.XDR.SCObject do
+  @moduledoc """
+  Representation of Stellar `SCObjectStellarBase.XDR.SCObject` type.
+  """
+  alias StellarBase.XDR.{AccountID, Hash, SCAddressType}
+
+  @behaviour XDR.Declaration
+
+  @arms [
+    SC_ADDRESS_TYPE_ACCOUNT: AccountID,
+    SC_ADDRESS_TYPE_CONTRACT: Hash
+  ]
+
+  @type sc_address :: AccountID.t() | Hash.t()
+
+  @type t :: %__MODULE__{sc_address: sc_address(), type: SCAddressType.t()}
+
+  defstruct [:sc_address, :type]
+
+  @spec new(sc_address :: sc_address(), type :: SCAddressType.t()) :: t()
+  def new(sc_address, %SCAddressType{} = type),
+    do: %__MODULE__{sc_address: sc_address, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{sc_address: sc_address, type: type}) do
+    type
+    |> XDR.Union.new(@arms, sc_address)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{sc_address: sc_address, type: type}) do
+    type
+    |> XDR.Union.new(@arms, sc_address)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{type, sc_address}, rest}} -> {:ok, {new(sc_address, type), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{type, sc_address}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(sc_address, type), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> SCAddressType.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/contract/sc_object.ex
+++ b/lib/xdr/contract/sc_object.ex
@@ -2,36 +2,62 @@ defmodule StellarBase.XDR.SCObject do
   @moduledoc """
   Representation of Stellar `SCObjectStellarBase.XDR.SCObject` type.
   """
-  alias StellarBase.XDR.{AccountID, Hash, SCAddressType}
+  alias StellarBase.XDR.{
+    Int128Parts,
+    Int64,
+    SCAddress,
+    SCContractCode,
+    SCMap,
+    SCObjectType,
+    SCVec,
+    UInt64,
+    VariableOpaque256000
+  }
 
   @behaviour XDR.Declaration
 
   @arms [
-    SC_ADDRESS_TYPE_ACCOUNT: AccountID,
-    SC_ADDRESS_TYPE_CONTRACT: Hash
+    SCO_VEC: SCVec,
+    SCO_MAP: SCMap,
+    SCO_U64: UInt64,
+    SCO_I64: Int64,
+    SCO_U128: Int128Parts,
+    SCO_I128: Int128Parts,
+    SCO_BYTES: VariableOpaque256000,
+    SCO_CONTRACT_CODE: SCContractCode,
+    SCO_ADDRESS: SCAddress,
+    SCO_NONCE_KEY: SCAddress
   ]
 
-  @type sc_address :: AccountID.t() | Hash.t()
+  @type sc_object ::
+          SCVec.t()
+          | SCMap.t()
+          | UInt64.t()
+          | Int64.t()
+          | Int128Parts.t()
+          | VariableOpaque256000.t()
+          | SCContractCode.t()
+          | SCAddress.t()
 
-  @type t :: %__MODULE__{sc_address: sc_address(), type: SCAddressType.t()}
+  @type t :: %__MODULE__{sc_object: sc_object(), type: SCObjectType.t()}
 
-  defstruct [:sc_address, :type]
+  defstruct [:sc_object, :type]
 
-  @spec new(sc_address :: sc_address(), type :: SCAddressType.t()) :: t()
-  def new(sc_address, %SCAddressType{} = type),
-    do: %__MODULE__{sc_address: sc_address, type: type}
+  @spec new(sc_object :: sc_object(), type :: SCObjectType.t()) :: t()
+  def new(sc_object, %SCObjectType{} = type),
+    do: %__MODULE__{sc_object: sc_object, type: type}
 
   @impl true
-  def encode_xdr(%__MODULE__{sc_address: sc_address, type: type}) do
+  def encode_xdr(%__MODULE__{sc_object: sc_object, type: type}) do
     type
-    |> XDR.Union.new(@arms, sc_address)
+    |> XDR.Union.new(@arms, sc_object)
     |> XDR.Union.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{sc_address: sc_address, type: type}) do
+  def encode_xdr!(%__MODULE__{sc_object: sc_object, type: type}) do
     type
-    |> XDR.Union.new(@arms, sc_address)
+    |> XDR.Union.new(@arms, sc_object)
     |> XDR.Union.encode_xdr!()
   end
 
@@ -40,7 +66,7 @@ defmodule StellarBase.XDR.SCObject do
 
   def decode_xdr(bytes, spec) do
     case XDR.Union.decode_xdr(bytes, spec) do
-      {:ok, {{type, sc_address}, rest}} -> {:ok, {new(sc_address, type), rest}}
+      {:ok, {{type, sc_object}, rest}} -> {:ok, {new(sc_object, type), rest}}
       error -> error
     end
   end
@@ -49,14 +75,14 @@ defmodule StellarBase.XDR.SCObject do
   def decode_xdr!(bytes, spec \\ union_spec())
 
   def decode_xdr!(bytes, spec) do
-    {{type, sc_address}, rest} = XDR.Union.decode_xdr!(bytes, spec)
-    {new(sc_address, type), rest}
+    {{type, sc_object}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(sc_object, type), rest}
   end
 
   @spec union_spec() :: XDR.Union.t()
   defp union_spec do
     nil
-    |> SCAddressType.new()
+    |> SCObjectType.new()
     |> XDR.Union.new(@arms)
   end
 end

--- a/lib/xdr/contract/sc_object.ex
+++ b/lib/xdr/contract/sc_object.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCObject do
   @moduledoc """
   Representation of Stellar `SCObjectStellarBase.XDR.SCObject` type.
   """
+
   alias StellarBase.XDR.{
     Int128Parts,
     Int64,
@@ -44,8 +45,7 @@ defmodule StellarBase.XDR.SCObject do
   defstruct [:sc_object, :type]
 
   @spec new(sc_object :: sc_object(), type :: SCObjectType.t()) :: t()
-  def new(sc_object, %SCObjectType{} = type),
-    do: %__MODULE__{sc_object: sc_object, type: type}
+  def new(sc_object, %SCObjectType{} = type), do: %__MODULE__{sc_object: sc_object, type: type}
 
   @impl true
   def encode_xdr(%__MODULE__{sc_object: sc_object, type: type}) do

--- a/lib/xdr/contract/sc_object_type.ex
+++ b/lib/xdr/contract/sc_object_type.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCObjectType do
   @moduledoc """
   Representation of Stellar `SCObjectType` type.
   """
+
   @behaviour XDR.Declaration
 
   @declarations [

--- a/lib/xdr/contract/sc_object_type.ex
+++ b/lib/xdr/contract/sc_object_type.ex
@@ -1,0 +1,60 @@
+defmodule StellarBase.XDR.SCObjectType do
+  @moduledoc """
+  Representation of Stellar `SCObjectType` type.
+  """
+  @behaviour XDR.Declaration
+
+  @declarations [
+    SCO_VEC: 0,
+    SCO_MAP: 1,
+    SCO_U64: 2,
+    SCO_I64: 3,
+    SCO_U128: 4,
+    SCO_I128: 5,
+    SCO_BYTES: 6,
+    SCO_CONTRACT_CODE: 7,
+    SCO_ADDRESS: 8,
+    SCO_NONCE_KEY: 9
+  ]
+
+  @enum_spec %XDR.Enum{declarations: @declarations, identifier: nil}
+
+  @type t :: %__MODULE__{identifier: atom()}
+
+  defstruct [:identifier]
+
+  @spec new(code :: atom()) :: t()
+  def new(code), do: %__MODULE__{identifier: code}
+
+  @impl true
+  def encode_xdr(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{identifier: code}) do
+    @declarations
+    |> XDR.Enum.new(code)
+    |> XDR.Enum.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @enum_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Enum.decode_xdr(bytes, spec) do
+      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @enum_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(code), rest}
+  end
+end

--- a/lib/xdr/contract/sc_object_type.ex
+++ b/lib/xdr/contract/sc_object_type.ex
@@ -24,20 +24,20 @@ defmodule StellarBase.XDR.SCObjectType do
 
   defstruct [:identifier]
 
-  @spec new(code :: atom()) :: t()
-  def new(code), do: %__MODULE__{identifier: code}
+  @spec new(type :: atom()) :: t()
+  def new(type), do: %__MODULE__{identifier: type}
 
   @impl true
-  def encode_xdr(%__MODULE__{identifier: code}) do
+  def encode_xdr(%__MODULE__{identifier: type}) do
     @declarations
-    |> XDR.Enum.new(code)
+    |> XDR.Enum.new(type)
     |> XDR.Enum.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{identifier: code}) do
+  def encode_xdr!(%__MODULE__{identifier: type}) do
     @declarations
-    |> XDR.Enum.new(code)
+    |> XDR.Enum.new(type)
     |> XDR.Enum.encode_xdr!()
   end
 
@@ -46,7 +46,7 @@ defmodule StellarBase.XDR.SCObjectType do
 
   def decode_xdr(bytes, spec) do
     case XDR.Enum.decode_xdr(bytes, spec) do
-      {:ok, {%XDR.Enum{identifier: code}, rest}} -> {:ok, {new(code), rest}}
+      {:ok, {%XDR.Enum{identifier: type}, rest}} -> {:ok, {new(type), rest}}
       error -> error
     end
   end
@@ -55,7 +55,7 @@ defmodule StellarBase.XDR.SCObjectType do
   def decode_xdr!(bytes, spec \\ @enum_spec)
 
   def decode_xdr!(bytes, spec) do
-    {%XDR.Enum{identifier: code}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
-    {new(code), rest}
+    {%XDR.Enum{identifier: type}, rest} = XDR.Enum.decode_xdr!(bytes, spec)
+    {new(type), rest}
   end
 end

--- a/lib/xdr/contract/sc_status.ex
+++ b/lib/xdr/contract/sc_status.ex
@@ -1,0 +1,93 @@
+defmodule StellarBase.XDR.SCStatus do
+  @moduledoc """
+  Representation of Stellar `SCStatus` type.
+  """
+  alias StellarBase.XDR.{
+    SCUnknownErrorCode,
+    SCHostValErrorCode,
+    SCHostObjErrorCode,
+    SCHostFnErrorCode,
+    SCHostStorageErrorCode,
+    SCHostContextErrorCode,
+    SCVmErrorCode,
+    SCHostAuthErrorCode,
+    SCStatusType,
+    UInt32,
+    Void
+  }
+
+  @behaviour XDR.Declaration
+
+  @arms [
+    SST_OK: Void,
+    SST_UNKNOWN_ERROR: SCUnknownErrorCode,
+    SST_HOST_VALUE_ERROR: SCHostValErrorCode,
+    SST_HOST_OBJECT_ERROR: SCHostObjErrorCode,
+    SST_HOST_FUNCTION_ERROR: SCHostFnErrorCode,
+    SST_HOST_STORAGE_ERROR: SCHostStorageErrorCode,
+    SST_HOST_CONTEXT_ERROR: SCHostContextErrorCode,
+    SST_VM_ERROR: SCVmErrorCode,
+    SST_CONTRACT_ERROR: UInt32,
+    SST_HOST_AUTH_ERROR: SCHostAuthErrorCode
+  ]
+
+  @type code ::
+          SCUnknownErrorCode.t()
+          | SCHostValErrorCode.t()
+          | SCHostObjErrorCode.t()
+          | SCHostFnErrorCode.t()
+          | SCHostStorageErrorCode.t()
+          | SCHostContextErrorCode.t()
+          | SCVmErrorCode.t()
+          | SCHostAuthErrorCode.t()
+          | SCStatusType.t()
+          | UInt32.t()
+          | Void
+
+  @type t :: %__MODULE__{code: code(), type: SCStatusType.t()}
+
+  defstruct [:code, :type]
+
+  @spec new(code :: code(), type :: SCStatusType.t()) :: t()
+  def new(code, %SCStatusType{} = type),
+    do: %__MODULE__{code: code, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{code: code, type: type}) do
+    type
+    |> XDR.Union.new(@arms, code)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{code: code, type: type}) do
+    type
+    |> XDR.Union.new(@arms, code)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{type, code}, rest}} -> {:ok, {new(code, type), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{type, code}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(code, type), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> SCStatusType.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/contract/sc_status.ex
+++ b/lib/xdr/contract/sc_status.ex
@@ -43,7 +43,7 @@ defmodule StellarBase.XDR.SCStatus do
           | SCHostAuthErrorCode.t()
           | SCStatusType.t()
           | UInt32.t()
-          | Void
+          | Void.t()
 
   @type t :: %__MODULE__{code: code(), type: SCStatusType.t()}
 

--- a/lib/xdr/contract/sc_status.ex
+++ b/lib/xdr/contract/sc_status.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCStatus do
   @moduledoc """
   Representation of Stellar `SCStatus` type.
   """
+
   alias StellarBase.XDR.{
     SCUnknownErrorCode,
     SCHostValErrorCode,
@@ -49,8 +50,7 @@ defmodule StellarBase.XDR.SCStatus do
   defstruct [:code, :type]
 
   @spec new(code :: code(), type :: SCStatusType.t()) :: t()
-  def new(code, %SCStatusType{} = type),
-    do: %__MODULE__{code: code, type: type}
+  def new(code, %SCStatusType{} = type), do: %__MODULE__{code: code, type: type}
 
   @impl true
   def encode_xdr(%__MODULE__{code: code, type: type}) do

--- a/lib/xdr/contract/sc_val.ex
+++ b/lib/xdr/contract/sc_val.ex
@@ -28,7 +28,7 @@ defmodule StellarBase.XDR.SCVal do
     SCV_STATUS: SCStatus
   ]
 
-  @type code ::
+  @type value ::
           Int64.t()
           | UInt32.t()
           | Int32.t()
@@ -38,24 +38,24 @@ defmodule StellarBase.XDR.SCVal do
           | UInt64.t()
           | SCStatus.t()
 
-  @type t :: %__MODULE__{code: code(), type: SCValType.t()}
+  @type t :: %__MODULE__{value: value(), type: SCValType.t()}
 
-  defstruct [:code, :type]
+  defstruct [:value, :type]
 
-  @spec new(code :: code(), type :: SCValType.t()) :: t()
-  def new(code, %SCValType{} = type), do: %__MODULE__{code: code, type: type}
+  @spec new(value :: value(), type :: SCValType.t()) :: t()
+  def new(value, %SCValType{} = type), do: %__MODULE__{value: value, type: type}
 
   @impl true
-  def encode_xdr(%__MODULE__{code: code, type: type}) do
+  def encode_xdr(%__MODULE__{value: value, type: type}) do
     type
-    |> XDR.Union.new(@arms, code)
+    |> XDR.Union.new(@arms, value)
     |> XDR.Union.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{code: code, type: type}) do
+  def encode_xdr!(%__MODULE__{value: value, type: type}) do
     type
-    |> XDR.Union.new(@arms, code)
+    |> XDR.Union.new(@arms, value)
     |> XDR.Union.encode_xdr!()
   end
 
@@ -64,7 +64,7 @@ defmodule StellarBase.XDR.SCVal do
 
   def decode_xdr(bytes, spec) do
     case XDR.Union.decode_xdr(bytes, spec) do
-      {:ok, {{type, code}, rest}} -> {:ok, {new(code, type), rest}}
+      {:ok, {{type, value}, rest}} -> {:ok, {new(value, type), rest}}
       error -> error
     end
   end
@@ -73,8 +73,8 @@ defmodule StellarBase.XDR.SCVal do
   def decode_xdr!(bytes, spec \\ union_spec())
 
   def decode_xdr!(bytes, spec) do
-    {{type, code}, rest} = XDR.Union.decode_xdr!(bytes, spec)
-    {new(code, type), rest}
+    {{type, value}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(value, type), rest}
   end
 
   @spec union_spec() :: XDR.Union.t()

--- a/lib/xdr/contract/sc_val.ex
+++ b/lib/xdr/contract/sc_val.ex
@@ -1,0 +1,87 @@
+defmodule StellarBase.XDR.SCVal do
+  @moduledoc """
+  Representation of Stellar `SCVal` type.
+  """
+  alias StellarBase.XDR.{
+    Int64,
+    Int32,
+    UInt32,
+    UInt64,
+    SCValType,
+    SCStatic,
+    # SCV_OBJECT,
+    SCStatus,
+    SCSymbol
+  }
+
+  @behaviour XDR.Declaration
+
+  # cambiar por codes?
+  @arms [
+    SCV_U63: Int64,
+    SCV_U32: UInt32,
+    SCV_I32: Int32,
+    SCV_STATIC: SCStatic,
+    # SCV_OBJECT: SCObject,
+    SCV_SYMBOL: SCSymbol,
+    SCV_BITSET: UInt64,
+    SCV_STATUS: SCStatus
+  ]
+
+  @type code ::
+          Int64.t()
+          | UInt32.t()
+          | Int32.t()
+          | SCStatic.t()
+          # | SCObject.t()
+          | SCSymbol.t()
+          | UInt64.t()
+          | SCStatus.t()
+
+  @type t :: %__MODULE__{code: code(), type: SCValType.t()}
+
+  defstruct [:code, :type]
+
+  @spec new(code :: code(), type :: SCValType.t()) :: t()
+  def new(code, %SCValType{} = type),
+    do: %__MODULE__{code: code, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{code: code, type: type}) do
+    type
+    |> XDR.Union.new(@arms, code)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{code: code, type: type}) do
+    type
+    |> XDR.Union.new(@arms, code)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{type, code}, rest}} -> {:ok, {new(code, type), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{type, code}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(code, type), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> SCValType.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/contract/sc_val.ex
+++ b/lib/xdr/contract/sc_val.ex
@@ -5,24 +5,23 @@ defmodule StellarBase.XDR.SCVal do
   alias StellarBase.XDR.{
     Int64,
     Int32,
+    OptionalSCObject,
     UInt32,
     UInt64,
     SCValType,
     SCStatic,
-    # SCV_OBJECT,
     SCStatus,
     SCSymbol
   }
 
   @behaviour XDR.Declaration
 
-  # cambiar por codes?
   @arms [
     SCV_U63: Int64,
     SCV_U32: UInt32,
     SCV_I32: Int32,
     SCV_STATIC: SCStatic,
-    # SCV_OBJECT: SCObject,
+    SCV_OBJECT: OptionalSCObject,
     SCV_SYMBOL: SCSymbol,
     SCV_BITSET: UInt64,
     SCV_STATUS: SCStatus
@@ -33,7 +32,7 @@ defmodule StellarBase.XDR.SCVal do
           | UInt32.t()
           | Int32.t()
           | SCStatic.t()
-          # | SCObject.t()
+          | OptionalSCObject.t()
           | SCSymbol.t()
           | UInt64.t()
           | SCStatus.t()

--- a/lib/xdr/contract/sc_val.ex
+++ b/lib/xdr/contract/sc_val.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCVal do
   @moduledoc """
   Representation of Stellar `SCVal` type.
   """
+
   alias StellarBase.XDR.{
     Int64,
     Int32,
@@ -42,8 +43,7 @@ defmodule StellarBase.XDR.SCVal do
   defstruct [:code, :type]
 
   @spec new(code :: code(), type :: SCValType.t()) :: t()
-  def new(code, %SCValType{} = type),
-    do: %__MODULE__{code: code, type: type}
+  def new(code, %SCValType{} = type), do: %__MODULE__{code: code, type: type}
 
   @impl true
   def encode_xdr(%__MODULE__{code: code, type: type}) do

--- a/lib/xdr/contract/sc_vec.ex
+++ b/lib/xdr/contract/sc_vec.ex
@@ -1,0 +1,49 @@
+defmodule StellarBase.XDR.SCVec do
+  @moduledoc """
+  Representation of Stellar `SCVec type.
+  """
+  alias StellarBase.XDR.SCVal
+  @behaviour XDR.Declaration
+  @max_length 256_000
+  @array_type SCVal
+  @array_spec %{type: @array_type, max_length: @max_length}
+
+  @type t :: %__MODULE__{vector: list(SCVal.t())}
+
+  defstruct [:vector]
+
+  @spec new(vector :: list(SCVal.t())) :: t()
+  def new(vector), do: %__MODULE__{vector: vector}
+
+  @impl true
+  def encode_xdr(%__MODULE__{vector: vector}) do
+    vector
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{vector: vector}) do
+    vector
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @array_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.VariableArray.decode_xdr(bytes, spec) do
+      {:ok, {vector, rest}} -> {:ok, {new(vector), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @array_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {vector, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(vector), rest}
+  end
+end

--- a/lib/xdr/contract/sc_vec.ex
+++ b/lib/xdr/contract/sc_vec.ex
@@ -1,30 +1,34 @@
 defmodule StellarBase.XDR.SCVec do
   @moduledoc """
-  Representation of Stellar `SCVec type.
+  Representation of Stellar `SCVec` list.
   """
   alias StellarBase.XDR.SCVal
+
   @behaviour XDR.Declaration
+
   @max_length 256_000
+
   @array_type SCVal
+
   @array_spec %{type: @array_type, max_length: @max_length}
 
-  @type t :: %__MODULE__{vector: list(SCVal.t())}
+  @type t :: %__MODULE__{scvals: list(SCVal.t())}
 
-  defstruct [:vector]
+  defstruct [:scvals]
 
-  @spec new(vector :: list(SCVal.t())) :: t()
-  def new(vector), do: %__MODULE__{vector: vector}
+  @spec new(scvals :: list(SCVal.t())) :: t()
+  def new(scvals), do: %__MODULE__{scvals: scvals}
 
   @impl true
-  def encode_xdr(%__MODULE__{vector: vector}) do
-    vector
+  def encode_xdr(%__MODULE__{scvals: scvals}) do
+    scvals
     |> XDR.VariableArray.new(@array_type, @max_length)
     |> XDR.VariableArray.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{vector: vector}) do
-    vector
+  def encode_xdr!(%__MODULE__{scvals: scvals}) do
+    scvals
     |> XDR.VariableArray.new(@array_type, @max_length)
     |> XDR.VariableArray.encode_xdr!()
   end
@@ -34,7 +38,7 @@ defmodule StellarBase.XDR.SCVec do
 
   def decode_xdr(bytes, spec) do
     case XDR.VariableArray.decode_xdr(bytes, spec) do
-      {:ok, {vector, rest}} -> {:ok, {new(vector), rest}}
+      {:ok, {scvals, rest}} -> {:ok, {new(scvals), rest}}
       error -> error
     end
   end
@@ -43,7 +47,7 @@ defmodule StellarBase.XDR.SCVec do
   def decode_xdr!(bytes, spec \\ @array_spec)
 
   def decode_xdr!(bytes, spec) do
-    {vector, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
-    {new(vector), rest}
+    {scvals, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(scvals), rest}
   end
 end

--- a/lib/xdr/contract/sc_vec.ex
+++ b/lib/xdr/contract/sc_vec.ex
@@ -13,23 +13,23 @@ defmodule StellarBase.XDR.SCVec do
 
   @array_spec %{type: @array_type, max_length: @max_length}
 
-  @type t :: %__MODULE__{scvals: list(SCVal.t())}
+  @type t :: %__MODULE__{sc_vals: list(SCVal.t())}
 
-  defstruct [:scvals]
+  defstruct [:sc_vals]
 
-  @spec new(scvals :: list(SCVal.t())) :: t()
-  def new(scvals), do: %__MODULE__{scvals: scvals}
+  @spec new(sc_vals :: list(SCVal.t())) :: t()
+  def new(sc_vals), do: %__MODULE__{sc_vals: sc_vals}
 
   @impl true
-  def encode_xdr(%__MODULE__{scvals: scvals}) do
-    scvals
+  def encode_xdr(%__MODULE__{sc_vals: sc_vals}) do
+    sc_vals
     |> XDR.VariableArray.new(@array_type, @max_length)
     |> XDR.VariableArray.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{scvals: scvals}) do
-    scvals
+  def encode_xdr!(%__MODULE__{sc_vals: sc_vals}) do
+    sc_vals
     |> XDR.VariableArray.new(@array_type, @max_length)
     |> XDR.VariableArray.encode_xdr!()
   end
@@ -39,7 +39,7 @@ defmodule StellarBase.XDR.SCVec do
 
   def decode_xdr(bytes, spec) do
     case XDR.VariableArray.decode_xdr(bytes, spec) do
-      {:ok, {scvals, rest}} -> {:ok, {new(scvals), rest}}
+      {:ok, {sc_vals, rest}} -> {:ok, {new(sc_vals), rest}}
       error -> error
     end
   end
@@ -48,7 +48,7 @@ defmodule StellarBase.XDR.SCVec do
   def decode_xdr!(bytes, spec \\ @array_spec)
 
   def decode_xdr!(bytes, spec) do
-    {scvals, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
-    {new(scvals), rest}
+    {sc_vals, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(sc_vals), rest}
   end
 end

--- a/lib/xdr/contract/sc_vec.ex
+++ b/lib/xdr/contract/sc_vec.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.SCVec do
   @moduledoc """
   Representation of Stellar `SCVec` list.
   """
+
   alias StellarBase.XDR.SCVal
 
   @behaviour XDR.Declaration

--- a/lib/xdr/ledger_entries/asset_code12.ex
+++ b/lib/xdr/ledger_entries/asset_code12.ex
@@ -56,7 +56,7 @@ defmodule StellarBase.XDR.AssetCode12 do
   @spec build_opaque(code :: binary(), length :: non_neg_integer()) :: XDR.FixedOpaque.t()
   defp build_opaque(code, length) do
     zeros = @max_length - length
-    bin = <<code::binary, 0::zeros*8>>
+    bin = <<code::binary, 0::zeros()*8>>
     XDR.FixedOpaque.new(bin, @max_length)
   end
 

--- a/lib/xdr/ledger_entries/asset_code12.ex
+++ b/lib/xdr/ledger_entries/asset_code12.ex
@@ -56,7 +56,7 @@ defmodule StellarBase.XDR.AssetCode12 do
   @spec build_opaque(code :: binary(), length :: non_neg_integer()) :: XDR.FixedOpaque.t()
   defp build_opaque(code, length) do
     zeros = @max_length - length
-    bin = <<code::binary, 0::zeros()*8>>
+    bin = <<code::binary, 0::zeros*8>>
     XDR.FixedOpaque.new(bin, @max_length)
   end
 

--- a/lib/xdr/types/variable_opaque256000.ex
+++ b/lib/xdr/types/variable_opaque256000.ex
@@ -1,6 +1,6 @@
 defmodule StellarBase.XDR.VariableOpaque256000 do
   @moduledoc """
-  Representation of Stellar `VariableOpaque256000` type.` type.
+  Representation of Stellar `VariableOpaque256000` type.
   """
 
   @behaviour XDR.Declaration

--- a/lib/xdr/types/variable_opaque256000.ex
+++ b/lib/xdr/types/variable_opaque256000.ex
@@ -2,6 +2,7 @@ defmodule StellarBase.XDR.VariableOpaque256000 do
   @moduledoc """
   Representation of Stellar `VariableOpaque256000` type.` type.
   """
+
   @behaviour XDR.Declaration
 
   @type t :: %__MODULE__{opaque: binary()}

--- a/lib/xdr/types/variable_opaque256000.ex
+++ b/lib/xdr/types/variable_opaque256000.ex
@@ -1,0 +1,45 @@
+defmodule StellarBase.XDR.VariableOpaque256000 do
+  @moduledoc """
+  Representation of Stellar `VariableOpaque256000` type.` type.
+  """
+  @behaviour XDR.Declaration
+
+  @type t :: %__MODULE__{opaque: binary()}
+
+  defstruct [:opaque]
+
+  @max_size 256_000
+
+  @opaque_spec XDR.VariableOpaque.new(nil, @max_size)
+
+  @spec new(opaque :: binary()) :: t()
+  def new(opaque), do: %__MODULE__{opaque: opaque}
+
+  @impl true
+  def encode_xdr(%__MODULE__{opaque: opaque}) do
+    XDR.VariableOpaque.encode_xdr(%XDR.VariableOpaque{opaque: opaque, max_size: @max_size})
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{opaque: opaque}) do
+    XDR.VariableOpaque.encode_xdr!(%XDR.VariableOpaque{opaque: opaque, max_size: @max_size})
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @opaque_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.VariableOpaque.decode_xdr(bytes, spec) do
+      {:ok, {%XDR.VariableOpaque{opaque: opaque}, rest}} -> {:ok, {new(opaque), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @opaque_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {%XDR.VariableOpaque{opaque: opaque}, rest} = XDR.VariableOpaque.decode_xdr!(bytes, spec)
+    {new(opaque), rest}
+  end
+end

--- a/test/xdr/contract/int128_parts_test.exs
+++ b/test/xdr/contract/int128_parts_test.exs
@@ -3,8 +3,6 @@ defmodule StellarBase.XDR.Int128PartsTest do
 
   alias StellarBase.XDR.{Int128Parts, UInt64}
 
-  alias StellarBase.StrKey
-
   describe "Int128Parts" do
     setup do
       lo = UInt64.new(3312)

--- a/test/xdr/contract/int128_parts_test.exs
+++ b/test/xdr/contract/int128_parts_test.exs
@@ -1,0 +1,45 @@
+defmodule StellarBase.XDR.Int128PartsTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{Int128Parts, UInt64}
+
+  alias StellarBase.StrKey
+
+  describe "Int128Parts" do
+    setup do
+      lo = UInt64.new(3312)
+      hi = UInt64.new(3313)
+
+      %{
+        lo: lo,
+        hi: hi,
+        int128_parts: Int128Parts.new(lo, hi),
+        binary: <<0, 0, 0, 0, 0, 0, 12, 240, 0, 0, 0, 0, 0, 0, 12, 241>>
+      }
+    end
+
+    test "new/1", %{lo: lo, hi: hi} do
+      %Int128Parts{lo: ^lo, hi: ^hi} = Int128Parts.new(lo, hi)
+    end
+
+    test "encode_xdr/1", %{int128_parts: int128_parts, binary: binary} do
+      {:ok, ^binary} = Int128Parts.encode_xdr(int128_parts)
+    end
+
+    test "encode_xdr!/1", %{int128_parts: int128_parts, binary: binary} do
+      ^binary = Int128Parts.encode_xdr!(int128_parts)
+    end
+
+    test "decode_xdr/2", %{int128_parts: int128_parts, binary: binary} do
+      {:ok, {^int128_parts, ""}} = Int128Parts.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = Int128Parts.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{int128_parts: int128_parts, binary: binary} do
+      {^int128_parts, ^binary} = Int128Parts.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/optional_sc_object_test.exs
+++ b/test/xdr/contract/optional_sc_object_test.exs
@@ -1,0 +1,87 @@
+defmodule StellarBase.XDR.OptionalSCObjectTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    AccountID,
+    SCObject,
+    SCObjectType,
+    OptionalSCObject,
+    SCAddress,
+    SCAddressType,
+    PublicKey,
+    PublicKeyType,
+    UInt256
+  }
+
+  alias StellarBase.StrKey
+
+  describe "OptionalSCObject" do
+    setup do
+      pk_type = PublicKeyType.new(:PUBLIC_KEY_TYPE_ED25519)
+
+      account_id =
+        "GBZNLMUQMIN3VGUJISKZU7GNY3O3XLMYEHJCKCSMDHKLGSMKALRXOEZD"
+        |> StrKey.decode!(:ed25519_public_key)
+        |> UInt256.new()
+        |> PublicKey.new(pk_type)
+        |> AccountID.new()
+
+      sc_address_type = SCAddressType.new(:SC_ADDRESS_TYPE_ACCOUNT)
+
+      sc_address = SCAddress.new(account_id, sc_address_type)
+
+      sc_object_type = SCObjectType.new(:SCO_ADDRESS)
+
+      sc_object = SCObject.new(sc_address, sc_object_type)
+
+      %{
+        optional_sc_object: OptionalSCObject.new(sc_object),
+        empty_sc_object: OptionalSCObject.new(nil),
+        binary:
+          <<0, 0, 0, 1, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 114, 213, 178, 144, 98, 27, 186, 154,
+            137, 68, 149, 154, 124, 205, 198, 221, 187, 173, 152, 33, 210, 37, 10, 76, 25, 212,
+            179, 73, 138, 2, 227, 119>>
+      }
+    end
+
+    test "new/1", %{optional_sc_object: optional_sc_object} do
+      %OptionalSCObject{sc_object: ^optional_sc_object} = OptionalSCObject.new(optional_sc_object)
+    end
+
+    test "new/1 no sc_object opted" do
+      %OptionalSCObject{sc_object: nil} = OptionalSCObject.new(nil)
+    end
+
+    test "encode_xdr/1", %{optional_sc_object: optional_sc_object, binary: binary} do
+      {:ok, ^binary} = OptionalSCObject.encode_xdr(optional_sc_object)
+    end
+
+    test "encode_xdr/1 no sc_object opted", %{empty_sc_object: empty_sc_object} do
+      {:ok, <<0, 0, 0, 0>>} = OptionalSCObject.encode_xdr(empty_sc_object)
+    end
+
+    test "encode_xdr!/1", %{optional_sc_object: optional_sc_object, binary: binary} do
+      ^binary = OptionalSCObject.encode_xdr!(optional_sc_object)
+    end
+
+    test "decode_xdr/2", %{optional_sc_object: optional_sc_object, binary: binary} do
+      {:ok, {^optional_sc_object, ""}} = OptionalSCObject.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = OptionalSCObject.decode_xdr(1234)
+    end
+
+    test "decode_xdr/2 when sc_object is not opted" do
+      {:ok, {%OptionalSCObject{sc_object: nil}, ""}} = OptionalSCObject.decode_xdr(<<0, 0, 0, 0>>)
+    end
+
+    test "decode_xdr!/2", %{optional_sc_object: optional_sc_object, binary: binary} do
+      {^optional_sc_object, ^binary} = OptionalSCObject.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 when sc_object is not opted" do
+      {%OptionalSCObject{sc_object: nil}, ""} = OptionalSCObject.decode_xdr!(<<0, 0, 0, 0>>)
+    end
+  end
+end

--- a/test/xdr/contract/sc_address_test.exs
+++ b/test/xdr/contract/sc_address_test.exs
@@ -1,0 +1,77 @@
+defmodule StellarBase.XDR.SCAddressTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.SCAddress
+  alias StellarBase.XDR.SCAddressType
+
+  alias StellarBase.XDR.{
+    AccountID,
+    PublicKey,
+    PublicKeyType,
+    UInt256
+  }
+
+  alias StellarBase.StrKey
+
+  describe "SCAddress" do
+    setup do
+      pk_type = PublicKeyType.new(:PUBLIC_KEY_TYPE_ED25519)
+
+      account_id =
+        "GBZNLMUQMIN3VGUJISKZU7GNY3O3XLMYEHJCKCSMDHKLGSMKALRXOEZD"
+        |> StrKey.decode!(:ed25519_public_key)
+        |> UInt256.new()
+        |> PublicKey.new(pk_type)
+        |> AccountID.new()
+
+      sc_address_type = SCAddressType.new(:SC_ADDRESS_TYPE_ACCOUNT)
+
+      %{
+        account_id: account_id,
+        sc_address_type: sc_address_type,
+        sc_address: SCAddress.new(account_id, sc_address_type),
+        binary:
+          <<0, 0, 0, 0, 0, 0, 0, 0, 114, 213, 178, 144, 98, 27, 186, 154, 137, 68, 149, 154, 124,
+            205, 198, 221, 187, 173, 152, 33, 210, 37, 10, 76, 25, 212, 179, 73, 138, 2, 227,
+            119>>
+      }
+    end
+
+    test "new/1", %{account_id: account_id, sc_address_type: sc_address_type} do
+      %SCAddress{sc_address: ^account_id, type: ^sc_address_type} =
+        SCAddress.new(account_id, sc_address_type)
+    end
+
+    test "encode_xdr/1", %{sc_address: sc_address, binary: binary} do
+      {:ok, ^binary} = SCAddress.encode_xdr(sc_address)
+    end
+
+    test "encode_xdr/1 with an invalid type", %{account_id: account_id} do
+      sc_address_type = SCAddressType.new(:NEW_ADDRESS)
+
+      assert_raise XDR.EnumError,
+                   "The key which you try to encode doesn't belong to the current declarations",
+                   fn ->
+                     account_id
+                     |> SCAddress.new(sc_address_type)
+                     |> SCAddress.encode_xdr()
+                   end
+    end
+
+    test "encode_xdr!/1", %{sc_address: sc_address, binary: binary} do
+      ^binary = SCAddress.encode_xdr!(sc_address)
+    end
+
+    test "decode_xdr/2", %{sc_address: sc_address, binary: binary} do
+      {:ok, {^sc_address, ""}} = SCAddress.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCAddress.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{sc_address: sc_address, binary: binary} do
+      {^sc_address, ^binary} = SCAddress.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/sc_address_type_test.exs
+++ b/test/xdr/contract/sc_address_type_test.exs
@@ -1,0 +1,63 @@
+defmodule StellarBase.XDR.SCAddressTypeTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.SCAddressType
+
+  @codes [
+    :SC_ADDRESS_TYPE_ACCOUNT,
+    :SC_ADDRESS_TYPE_CONTRACT
+  ]
+
+  @binaries [
+    <<0, 0, 0, 0>>,
+    <<0, 0, 0, 1>>
+  ]
+
+  describe "SCAddressType" do
+    setup do
+      %{
+        codes: @codes,
+        results: @codes |> Enum.map(fn code -> SCAddressType.new(code) end),
+        binaries: @binaries
+      }
+    end
+
+    test "new/1", %{codes: types} do
+      for type <- types,
+          do: %SCAddressType{identifier: ^type} = SCAddressType.new(type)
+    end
+
+    test "encode_xdr/1", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {:ok, ^binary} = SCAddressType.encode_xdr(result)
+    end
+
+    test "encode_xdr/1 with an invalid code" do
+      {:error, :invalid_key} = SCAddressType.encode_xdr(%SCAddressType{identifier: :TEST})
+    end
+
+    test "encode_xdr!/1", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: ^binary = SCAddressType.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {:ok, {^result, ""}} = SCAddressType.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid declaration" do
+      {:error, :invalid_key} = SCAddressType.decode_xdr(<<1, 0, 0, 1>>)
+    end
+
+    test "decode_xdr!/2", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {^result, ^binary} = SCAddressType.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 with an error code", %{binaries: binaries} do
+      for binary <- binaries,
+          do: {%SCAddressType{identifier: _}, ""} = SCAddressType.decode_xdr!(binary)
+    end
+  end
+end

--- a/test/xdr/contract/sc_address_type_test.exs
+++ b/test/xdr/contract/sc_address_type_test.exs
@@ -17,7 +17,7 @@ defmodule StellarBase.XDR.SCAddressTypeTest do
     setup do
       %{
         codes: @codes,
-        results: @codes |> Enum.map(fn code -> SCAddressType.new(code) end),
+        results: Enum.map(@codes, &SCAddressType.new/1),
         binaries: @binaries
       }
     end

--- a/test/xdr/contract/sc_contract_code_test.exs
+++ b/test/xdr/contract/sc_contract_code_test.exs
@@ -1,18 +1,7 @@
 defmodule StellarBase.XDR.SCContractCodeTest do
   use ExUnit.Case
 
-  alias StellarBase.XDR.SCContractCode
-  alias StellarBase.XDR.SCContractCodeType
-
-  alias StellarBase.XDR.{
-    AccountID,
-    PublicKey,
-    PublicKeyType,
-    UInt256,
-    Hash
-  }
-
-  alias StellarBase.StrKey
+  alias StellarBase.XDR.{SCContractCode, SCContractCodeType, Hash}
 
   describe "SCContractCode" do
     setup do

--- a/test/xdr/contract/sc_contract_code_test.exs
+++ b/test/xdr/contract/sc_contract_code_test.exs
@@ -1,0 +1,70 @@
+defmodule StellarBase.XDR.SCContractCodeTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.SCContractCode
+  alias StellarBase.XDR.SCContractCodeType
+
+  alias StellarBase.XDR.{
+    AccountID,
+    PublicKey,
+    PublicKeyType,
+    UInt256,
+    Hash
+  }
+
+  alias StellarBase.StrKey
+
+  describe "SCContractCode" do
+    setup do
+      contract_code = Hash.new("GCIZ3GSM5XL7OUS4UP64THMDZ7CZ3ZWN")
+
+      sc_contract_code_type = SCContractCodeType.new(:SCCONTRACT_CODE_WASM_REF)
+
+      %{
+        contract_code: contract_code,
+        sc_contract_code_type: sc_contract_code_type,
+        sc_contract_code: SCContractCode.new(contract_code, sc_contract_code_type),
+        binary:
+          <<0, 0, 0, 0, 71, 67, 73, 90, 51, 71, 83, 77, 53, 88, 76, 55, 79, 85, 83, 52, 85, 80,
+            54, 52, 84, 72, 77, 68, 90, 55, 67, 90, 51, 90, 87, 78>>
+      }
+    end
+
+    test "new/1", %{contract_code: contract_code, sc_contract_code_type: sc_contract_code_type} do
+      %SCContractCode{contract_code: ^contract_code, type: ^sc_contract_code_type} =
+        SCContractCode.new(contract_code, sc_contract_code_type)
+    end
+
+    test "encode_xdr/1", %{sc_contract_code: sc_contract_code, binary: binary} do
+      {:ok, ^binary} = SCContractCode.encode_xdr(sc_contract_code)
+    end
+
+    test "encode_xdr/1 with an invalid type", %{contract_code: contract_code} do
+      sc_contract_code_type = SCContractCodeType.new(:NEW_CONTRACT)
+
+      assert_raise XDR.EnumError,
+                   "The key which you try to encode doesn't belong to the current declarations",
+                   fn ->
+                     contract_code
+                     |> SCContractCode.new(sc_contract_code_type)
+                     |> SCContractCode.encode_xdr()
+                   end
+    end
+
+    test "encode_xdr!/1", %{sc_contract_code: sc_contract_code, binary: binary} do
+      ^binary = SCContractCode.encode_xdr!(sc_contract_code)
+    end
+
+    test "decode_xdr/2", %{sc_contract_code: sc_contract_code, binary: binary} do
+      {:ok, {^sc_contract_code, ""}} = SCContractCode.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCContractCode.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{sc_contract_code: sc_contract_code, binary: binary} do
+      {^sc_contract_code, ^binary} = SCContractCode.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/sc_contract_code_type_test.exs
+++ b/test/xdr/contract/sc_contract_code_type_test.exs
@@ -17,7 +17,7 @@ defmodule StellarBase.XDR.SCContractCodeTypeTest do
     setup do
       %{
         codes: @codes,
-        results: @codes |> Enum.map(fn code -> SCContractCodeType.new(code) end),
+        results: Enum.map(@codes, &SCContractCodeType.new/1),
         binaries: @binaries
       }
     end

--- a/test/xdr/contract/sc_contract_code_type_test.exs
+++ b/test/xdr/contract/sc_contract_code_type_test.exs
@@ -1,0 +1,64 @@
+defmodule StellarBase.XDR.SCContractCodeTypeTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.SCContractCodeType
+
+  @codes [
+    :SCCONTRACT_CODE_WASM_REF,
+    :SCCONTRACT_CODE_TOKEN
+  ]
+
+  @binaries [
+    <<0, 0, 0, 0>>,
+    <<0, 0, 0, 1>>
+  ]
+
+  describe "SCContractCodeType" do
+    setup do
+      %{
+        codes: @codes,
+        results: @codes |> Enum.map(fn code -> SCContractCodeType.new(code) end),
+        binaries: @binaries
+      }
+    end
+
+    test "new/1", %{codes: types} do
+      for type <- types,
+          do: %SCContractCodeType{identifier: ^type} = SCContractCodeType.new(type)
+    end
+
+    test "encode_xdr/1", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {:ok, ^binary} = SCContractCodeType.encode_xdr(result)
+    end
+
+    test "encode_xdr/1 with an invalid code" do
+      {:error, :invalid_key} =
+        SCContractCodeType.encode_xdr(%SCContractCodeType{identifier: :TEST})
+    end
+
+    test "encode_xdr!/1", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: ^binary = SCContractCodeType.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {:ok, {^result, ""}} = SCContractCodeType.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid declaration" do
+      {:error, :invalid_key} = SCContractCodeType.decode_xdr(<<1, 0, 0, 1>>)
+    end
+
+    test "decode_xdr!/2", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {^result, ^binary} = SCContractCodeType.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 with an error code", %{binaries: binaries} do
+      for binary <- binaries,
+          do: {%SCContractCodeType{identifier: _}, ""} = SCContractCodeType.decode_xdr!(binary)
+    end
+  end
+end

--- a/test/xdr/contract/sc_host_auth_error_code_test.exs
+++ b/test/xdr/contract/sc_host_auth_error_code_test.exs
@@ -45,5 +45,4 @@ defmodule StellarBase.XDR.SCHostAuthErrorCodeTest do
       {:error, :invalid_key} =
         SCHostAuthErrorCode.encode_xdr(%SCHostAuthErrorCode{identifier: :HOST_TEST})
     end
-  end
 end

--- a/test/xdr/contract/sc_host_auth_error_code_test.exs
+++ b/test/xdr/contract/sc_host_auth_error_code_test.exs
@@ -45,4 +45,5 @@ defmodule StellarBase.XDR.SCHostAuthErrorCodeTest do
       {:error, :invalid_key} =
         SCHostAuthErrorCode.encode_xdr(%SCHostAuthErrorCode{identifier: :HOST_TEST})
     end
+  end
 end

--- a/test/xdr/contract/sc_map_entry_test.exs
+++ b/test/xdr/contract/sc_map_entry_test.exs
@@ -1,0 +1,43 @@
+defmodule StellarBase.XDR.SCMapEntryTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{SCMapEntry, SCVal, SCValType, Int64}
+
+  describe "SCMapEntry" do
+    setup do
+      key = SCVal.new(Int64.new(1), SCValType.new(:SCV_U63))
+      val = SCVal.new(Int64.new(2), SCValType.new(:SCV_U63))
+
+      %{
+        key: key,
+        val: val,
+        scmap_entry: SCMapEntry.new(key, val),
+        binary: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2>>
+      }
+    end
+
+    test "new/1", %{key: key, val: val} do
+      %SCMapEntry{key: ^key, val: ^val} = SCMapEntry.new(key, val)
+    end
+
+    test "encode_xdr/1", %{scmap_entry: scmap_entry, binary: binary} do
+      {:ok, ^binary} = SCMapEntry.encode_xdr(scmap_entry)
+    end
+
+    test "encode_xdr!/1", %{scmap_entry: scmap_entry, binary: binary} do
+      ^binary = SCMapEntry.encode_xdr!(scmap_entry)
+    end
+
+    test "decode_xdr/2", %{scmap_entry: scmap_entry, binary: binary} do
+      {:ok, {^scmap_entry, ""}} = SCMapEntry.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCMapEntry.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{scmap_entry: scmap_entry, binary: binary} do
+      {^scmap_entry, ^binary} = SCMapEntry.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/sc_map_test.exs
+++ b/test/xdr/contract/sc_map_test.exs
@@ -1,0 +1,64 @@
+defmodule StellarBase.XDR.SCMapTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    Int64,
+    SCMap,
+    SCMapEntry,
+    SCVal,
+    SCValType
+  }
+
+  describe "SCMap" do
+    setup do
+      key1 = SCVal.new(Int64.new(1), SCValType.new(:SCV_U63))
+      val1 = SCVal.new(Int64.new(2), SCValType.new(:SCV_U63))
+      scmap_entry1 = SCMapEntry.new(key1, val1)
+
+      key2 = SCVal.new(Int64.new(1), SCValType.new(:SCV_U63))
+      val2 = SCVal.new(Int64.new(2), SCValType.new(:SCV_U63))
+      scmap_entry2 = SCMapEntry.new(key2, val2)
+
+      scmap_list = [scmap_entry1, scmap_entry2]
+
+      %{
+        scmap_list: scmap_list,
+        claimants: SCMap.new(scmap_list),
+        binary:
+          <<0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2>>
+      }
+    end
+
+    test "new/1", %{scmap_list: scmap_list} do
+      %SCMap{claimants: ^scmap_list} = SCMap.new(scmap_list)
+    end
+
+    test "encode_xdr/1", %{claimants: claimants, binary: binary} do
+      {:ok, ^binary} = SCMap.encode_xdr(claimants)
+    end
+
+    test "encode_xdr/1 with invalid elements" do
+      {:error, :not_list} =
+        %{elements: nil}
+        |> SCMap.new()
+        |> SCMap.encode_xdr()
+    end
+
+    test "encode_xdr!/1", %{claimants: claimants, binary: binary} do
+      ^binary = SCMap.encode_xdr!(claimants)
+    end
+
+    test "decode_xdr/2", %{claimants: claimants, binary: binary} do
+      {:ok, {^claimants, ""}} = SCMap.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCMap.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{claimants: claimants, binary: binary} do
+      {^claimants, ^binary} = SCMap.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/sc_map_test.exs
+++ b/test/xdr/contract/sc_map_test.exs
@@ -19,23 +19,23 @@ defmodule StellarBase.XDR.SCMapTest do
       val2 = SCVal.new(Int64.new(2), SCValType.new(:SCV_U63))
       scmap_entry2 = SCMapEntry.new(key2, val2)
 
-      scmap_list = [scmap_entry1, scmap_entry2]
+      scmap_entries = [scmap_entry1, scmap_entry2]
 
       %{
-        scmap_list: scmap_list,
-        claimants: SCMap.new(scmap_list),
+        scmap_entries: scmap_entries,
+        scmap: SCMap.new(scmap_entries),
         binary:
           <<0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2>>
       }
     end
 
-    test "new/1", %{scmap_list: scmap_list} do
-      %SCMap{claimants: ^scmap_list} = SCMap.new(scmap_list)
+    test "new/1", %{scmap_entries: scmap_entries} do
+      %SCMap{scmap_entries: ^scmap_entries} = SCMap.new(scmap_entries)
     end
 
-    test "encode_xdr/1", %{claimants: claimants, binary: binary} do
-      {:ok, ^binary} = SCMap.encode_xdr(claimants)
+    test "encode_xdr/1", %{scmap: scmap, binary: binary} do
+      {:ok, ^binary} = SCMap.encode_xdr(scmap)
     end
 
     test "encode_xdr/1 with invalid elements" do
@@ -45,20 +45,20 @@ defmodule StellarBase.XDR.SCMapTest do
         |> SCMap.encode_xdr()
     end
 
-    test "encode_xdr!/1", %{claimants: claimants, binary: binary} do
-      ^binary = SCMap.encode_xdr!(claimants)
+    test "encode_xdr!/1", %{scmap: scmap, binary: binary} do
+      ^binary = SCMap.encode_xdr!(scmap)
     end
 
-    test "decode_xdr/2", %{claimants: claimants, binary: binary} do
-      {:ok, {^claimants, ""}} = SCMap.decode_xdr(binary)
+    test "decode_xdr/2", %{scmap: scmap, binary: binary} do
+      {:ok, {^scmap, ""}} = SCMap.decode_xdr(binary)
     end
 
     test "decode_xdr/2 with an invalid binary" do
       {:error, :not_binary} = SCMap.decode_xdr(123)
     end
 
-    test "decode_xdr!/2", %{claimants: claimants, binary: binary} do
-      {^claimants, ^binary} = SCMap.decode_xdr!(binary <> binary)
+    test "decode_xdr!/2", %{scmap: scmap, binary: binary} do
+      {^scmap, ^binary} = SCMap.decode_xdr!(binary <> binary)
     end
   end
 end

--- a/test/xdr/contract/sc_object_test.exs
+++ b/test/xdr/contract/sc_object_test.exs
@@ -56,7 +56,6 @@ defmodule StellarBase.XDR.SCObjectTest do
       contract_code = Hash.new("GCIZ3GSM5XL7OUS4UP64THMDZ7CZ3ZWN")
       sc_contract_code_type = SCContractCodeType.new(:SCCONTRACT_CODE_WASM_REF)
 
-
       discriminants = [
         %{
           sc_object_type: SCObjectType.new(:SCO_VEC),

--- a/test/xdr/contract/sc_object_test.exs
+++ b/test/xdr/contract/sc_object_test.exs
@@ -1,0 +1,216 @@
+defmodule StellarBase.XDR.SCObjectTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{SCAddress, SCAddressType, SCObject, SCObjectType}
+
+  alias StellarBase.XDR.{
+    AccountID,
+    PublicKey,
+    PublicKeyType,
+    Int64,
+    UInt256,
+    SCValType,
+    SCVal,
+    SCVec,
+    SCMap,
+    SCMapEntry,
+    SCContractCodeType,
+    SCContractCode,
+    Hash,
+    UInt64,
+    Int128Parts,
+    VariableOpaque256000
+  }
+
+  alias StellarBase.StrKey
+
+  describe "SCObject" do
+    setup do
+      ## SCVec structs
+      sc_val_type = SCValType.new(:SCV_U63)
+      int64 = Int64.new(2)
+      sc_val = SCVal.new(int64, sc_val_type)
+
+      ## SCMap structs
+      key = SCVal.new(Int64.new(1), SCValType.new(:SCV_U63))
+      val = SCVal.new(Int64.new(2), SCValType.new(:SCV_U63))
+      scmap_entry = SCMapEntry.new(key, val)
+
+      ## Int128Parts structs
+      lo = UInt64.new(3312)
+      hi = UInt64.new(3313)
+
+      ## SCAddresss structs
+      pk_type = PublicKeyType.new(:PUBLIC_KEY_TYPE_ED25519)
+
+      account_id =
+        "GBZNLMUQMIN3VGUJISKZU7GNY3O3XLMYEHJCKCSMDHKLGSMKALRXOEZD"
+        |> StrKey.decode!(:ed25519_public_key)
+        |> UInt256.new()
+        |> PublicKey.new(pk_type)
+        |> AccountID.new()
+
+      sc_address_type = SCAddressType.new(:SC_ADDRESS_TYPE_ACCOUNT)
+
+      ## SCContractCode structs
+      contract_code = Hash.new("GCIZ3GSM5XL7OUS4UP64THMDZ7CZ3ZWN")
+      sc_contract_code_type = SCContractCodeType.new(:SCCONTRACT_CODE_WASM_REF)
+
+
+      discriminants = [
+        %{
+          sc_object_type: SCObjectType.new(:SCO_VEC),
+          sc_object: SCVec.new([sc_val]),
+          binary: <<0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_MAP),
+          sc_object: SCMap.new([scmap_entry]),
+          binary:
+            <<0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+              0, 0, 0, 2>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_U64),
+          sc_object: UInt64.new(18_446_744_073_709_551_615),
+          binary: <<0, 0, 0, 2, 255, 255, 255, 255, 255, 255, 255, 255>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_I64),
+          sc_object: Int64.new(2),
+          binary: <<0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_U128),
+          sc_object: Int128Parts.new(lo, hi),
+          binary: <<0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 12, 240, 0, 0, 0, 0, 0, 0, 12, 241>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_I128),
+          sc_object: Int128Parts.new(lo, hi),
+          binary: <<0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 12, 240, 0, 0, 0, 0, 0, 0, 12, 241>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_BYTES),
+          sc_object:
+            VariableOpaque256000.new(<<0, 0, 0, 9, 71, 67, 73, 90, 51, 71, 83, 77, 53, 0, 0, 0>>),
+          binary:
+            <<0, 0, 0, 6, 0, 0, 0, 16, 0, 0, 0, 9, 71, 67, 73, 90, 51, 71, 83, 77, 53, 0, 0, 0>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_CONTRACT_CODE),
+          sc_object: SCContractCode.new(contract_code, sc_contract_code_type),
+          binary:
+            <<0, 0, 0, 7, 0, 0, 0, 0, 71, 67, 73, 90, 51, 71, 83, 77, 53, 88, 76, 55, 79, 85, 83,
+              52, 85, 80, 54, 52, 84, 72, 77, 68, 90, 55, 67, 90, 51, 90, 87, 78>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_ADDRESS),
+          sc_object: SCAddress.new(account_id, sc_address_type),
+          binary:
+            <<0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 114, 213, 178, 144, 98, 27, 186, 154, 137, 68,
+              149, 154, 124, 205, 198, 221, 187, 173, 152, 33, 210, 37, 10, 76, 25, 212, 179, 73,
+              138, 2, 227, 119>>
+        },
+        %{
+          sc_object_type: SCObjectType.new(:SCO_NONCE_KEY),
+          sc_object: SCAddress.new(account_id, sc_address_type),
+          binary:
+            <<0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 114, 213, 178, 144, 98, 27, 186, 154, 137, 68,
+              149, 154, 124, 205, 198, 221, 187, 173, 152, 33, 210, 37, 10, 76, 25, 212, 179, 73,
+              138, 2, 227, 119>>
+        }
+      ]
+
+      %{discriminants: discriminants}
+    end
+
+    test "new/1", %{discriminants: discriminants} do
+      for %{sc_object_type: sc_object_type, sc_object: sc_object} <- discriminants do
+        %SCObject{sc_object: ^sc_object, type: ^sc_object_type} =
+          SCObject.new(sc_object, sc_object_type)
+      end
+    end
+
+    test "encode_xdr/1", %{discriminants: discriminants} do
+      for %{sc_object: sc_object, sc_object_type: sc_object_type, binary: binary} <- discriminants do
+        xdr = SCObject.new(sc_object, sc_object_type)
+        {:ok, ^binary} = SCObject.encode_xdr(xdr)
+      end
+    end
+
+    test "encode_xdr!/1", %{discriminants: discriminants} do
+      for %{sc_object: sc_object, sc_object_type: sc_object_type, binary: binary} <- discriminants do
+        xdr = SCObject.new(sc_object, sc_object_type)
+        ^binary = SCObject.encode_xdr!(xdr)
+      end
+    end
+
+    test "encode_xdr/1 with an invalid type", %{discriminants: [sc_object | _rest]} do
+      sc_object_type = SCObjectType.new(:NEW_ADDRESS)
+
+      assert_raise XDR.EnumError,
+                   "The key which you try to encode doesn't belong to the current declarations",
+                   fn ->
+                     sc_object
+                     |> SCObject.new(sc_object_type)
+                     |> SCObject.encode_xdr()
+                   end
+    end
+
+    test "decode_xdr/2", %{discriminants: discriminants} do
+      for %{sc_object: sc_object, sc_object_type: sc_object_type, binary: binary} <- discriminants do
+        xdr = SCObject.new(sc_object, sc_object_type)
+        {:ok, {^xdr, ""}} = SCObject.decode_xdr(binary)
+      end
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCObject.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{discriminants: discriminants} do
+      for %{sc_object: sc_object, sc_object_type: sc_object_type, binary: binary} <- discriminants do
+        xdr = SCObject.new(sc_object, sc_object_type)
+        {^xdr, ""} = SCObject.decode_xdr!(binary)
+      end
+    end
+
+    # test "new/1", %{sc_address: sc_address, sc_object_type: sc_object_type} do
+    #   %SCObject{sc_address: ^sc_address, type: ^sc_object_type} =
+    #     SCObject.new(sc_address, sc_object_type)
+    # end
+
+    # test "encode_xdr/1", %{sc_object: sc_object, binary: binary} do
+    #   {:ok, ^binary} = SCObject.encode_xdr(sc_object)
+    # end
+
+    # test "encode_xdr/1 with an invalid type", %{sc_address: sc_address} do
+    #   sc_object_type = SCObjectType.new(:NEW_ADDRESS)
+
+    #   assert_raise XDR.EnumError,
+    #                "The key which you try to encode doesn't belong to the current declarations",
+    #                fn ->
+    #                  sc_address
+    #                  |> SCObject.new(sc_object_type)
+    #                  |> SCObject.encode_xdr()
+    #                end
+    # end
+
+    # test "encode_xdr!/1", %{sc_object: sc_object, binary: binary} do
+    #   ^binary = SCObject.encode_xdr!(sc_object)
+    # end
+
+    # test "decode_xdr/2", %{sc_object: sc_object, binary: binary} do
+    #   {:ok, {^sc_object, ""}} = SCObject.decode_xdr(binary)
+    # end
+
+    # test "decode_xdr/2 with an invalid binary" do
+    #   {:error, :not_binary} = SCObject.decode_xdr(123)
+    # end
+
+    # test "decode_xdr!/2", %{sc_object: sc_object, binary: binary} do
+    #   {^sc_object, ^binary} = SCObject.decode_xdr!(binary <> binary)
+    # end
+  end
+end

--- a/test/xdr/contract/sc_object_type_test.exs
+++ b/test/xdr/contract/sc_object_type_test.exs
@@ -1,0 +1,79 @@
+defmodule StellarBase.XDR.SCObjectTypeTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.SCObjectType
+
+  @codes [
+    :SCO_VEC,
+    :SCO_MAP,
+    :SCO_U64,
+    :SCO_I64,
+    :SCO_U128,
+    :SCO_I128,
+    :SCO_BYTES,
+    :SCO_CONTRACT_CODE,
+    :SCO_ADDRESS,
+    :SCO_NONCE_KEY
+  ]
+
+  @binaries [
+    <<0, 0, 0, 0>>,
+    <<0, 0, 0, 1>>,
+    <<0, 0, 0, 2>>,
+    <<0, 0, 0, 3>>,
+    <<0, 0, 0, 4>>,
+    <<0, 0, 0, 5>>,
+    <<0, 0, 0, 6>>,
+    <<0, 0, 0, 7>>,
+    <<0, 0, 0, 8>>,
+    <<0, 0, 0, 9>>
+  ]
+
+  describe "SCObjectType" do
+    setup do
+      %{
+        codes: @codes,
+        results: @codes |> Enum.map(fn code -> SCObjectType.new(code) end),
+        binaries: @binaries
+      }
+    end
+
+    test "new/1", %{codes: types} do
+      for type <- types,
+          do: %SCObjectType{identifier: ^type} = SCObjectType.new(type)
+    end
+
+    test "encode_xdr/1", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {:ok, ^binary} = SCObjectType.encode_xdr(result)
+    end
+
+    test "encode_xdr/1 with an invalid code" do
+      {:error, :invalid_key} = SCObjectType.encode_xdr(%SCObjectType{identifier: :TEST})
+    end
+
+    test "encode_xdr!/1", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: ^binary = SCObjectType.encode_xdr!(result)
+    end
+
+    test "decode_xdr/2", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {:ok, {^result, ""}} = SCObjectType.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid declaration" do
+      {:error, :invalid_key} = SCObjectType.decode_xdr(<<1, 0, 0, 1>>)
+    end
+
+    test "decode_xdr!/2", %{results: results, binaries: binaries} do
+      for {result, binary} <- Enum.zip(results, binaries),
+          do: {^result, ^binary} = SCObjectType.decode_xdr!(binary <> binary)
+    end
+
+    test "decode_xdr!/2 with an error code", %{binaries: binaries} do
+      for binary <- binaries,
+          do: {%SCObjectType{identifier: _}, ""} = SCObjectType.decode_xdr!(binary)
+    end
+  end
+end

--- a/test/xdr/contract/sc_object_type_test.exs
+++ b/test/xdr/contract/sc_object_type_test.exs
@@ -33,7 +33,7 @@ defmodule StellarBase.XDR.SCObjectTypeTest do
     setup do
       %{
         codes: @codes,
-        results: @codes |> Enum.map(fn code -> SCObjectType.new(code) end),
+        results: Enum.map(@codes, &SCObjectType.new/1),
         binaries: @binaries
       }
     end

--- a/test/xdr/contract/sc_status_test.exs
+++ b/test/xdr/contract/sc_status_test.exs
@@ -1,0 +1,120 @@
+defmodule StellarBase.XDR.SCStatusTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.SCStatus
+  alias StellarBase.XDR.SCStatusType
+  alias StellarBase.XDR.SCStatusTest
+
+  alias StellarBase.XDR.{
+    SCUnknownErrorCode,
+    SCHostValErrorCode,
+    SCHostObjErrorCode,
+    SCHostFnErrorCode,
+    SCHostStorageErrorCode,
+    SCHostContextErrorCode,
+    SCVmErrorCode,
+    SCHostAuthErrorCode,
+    SCStatusType,
+    UInt32,
+    Void
+  }
+
+  alias StellarBase.StrKey
+
+  describe "SCStatus" do
+    setup do
+      discriminants = [
+        %{
+          status_type: SCStatusType.new(:SST_OK),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_UNKNOWN_ERROR),
+          sc_code: SCUnknownErrorCode.new(:UNKNOWN_ERROR_GENERAL),
+          binary: <<0, 0, 0, 1, 0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_HOST_VALUE_ERROR),
+          sc_code: SCHostValErrorCode.new(:HOST_VALUE_UNKNOWN_ERROR),
+          binary: <<0, 0, 0, 2, 0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_HOST_OBJECT_ERROR),
+          sc_code: SCHostObjErrorCode.new(:HOST_OBJECT_UNKNOWN_ERROR),
+          binary: <<0, 0, 0, 3, 0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_HOST_FUNCTION_ERROR),
+          sc_code: SCHostFnErrorCode.new(:HOST_FN_UNKNOWN_ERROR),
+          binary: <<0, 0, 0, 4, 0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_HOST_STORAGE_ERROR),
+          sc_code: SCHostStorageErrorCode.new(:HOST_STORAGE_UNKNOWN_ERROR),
+          binary: <<0, 0, 0, 5, 0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_HOST_CONTEXT_ERROR),
+          sc_code: SCHostContextErrorCode.new(:HOST_CONTEXT_UNKNOWN_ERROR),
+          binary: <<0, 0, 0, 6, 0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_VM_ERROR),
+          sc_code: SCVmErrorCode.new(:VM_UNKNOWN),
+          binary: <<0, 0, 0, 7, 0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_CONTRACT_ERROR),
+          sc_code: UInt32.new(3312),
+          binary: <<0, 0, 0, 8, 0, 0, 12, 240>>
+        },
+        %{
+          status_type: SCStatusType.new(:SST_HOST_AUTH_ERROR),
+          sc_code: SCHostAuthErrorCode.new(:HOST_AUTH_UNKNOWN_ERROR),
+          binary: <<0, 0, 0, 9, 0, 0, 0, 0>>
+        }
+      ]
+
+      %{discriminants: discriminants}
+    end
+
+    test "new/1", %{discriminants: discriminants} do
+      for %{status_type: status_type, sc_code: sc_code} <- discriminants do
+        %SCStatus{code: ^sc_code, type: ^status_type} = SCStatus.new(sc_code, status_type)
+      end
+    end
+
+    test "encode_xdr/1", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, status_type: status_type, binary: binary} <- discriminants do
+        xdr = SCStatus.new(sc_code, status_type)
+        {:ok, ^binary} = SCStatus.encode_xdr(xdr)
+      end
+    end
+
+    test "encode_xdr!/1", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, status_type: status_type, binary: binary} <- discriminants do
+        xdr = SCStatus.new(sc_code, status_type)
+        ^binary = SCStatus.encode_xdr!(xdr)
+      end
+    end
+
+    test "decode_xdr/2", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, status_type: status_type, binary: binary} <- discriminants do
+        xdr = SCStatus.new(sc_code, status_type)
+        {:ok, {^xdr, ""}} = SCStatus.decode_xdr(binary)
+      end
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCStatus.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, status_type: status_type, binary: binary} <- discriminants do
+        xdr = SCStatus.new(sc_code, status_type)
+        {^xdr, ""} = SCStatus.decode_xdr!(binary)
+      end
+    end
+  end
+end

--- a/test/xdr/contract/sc_status_test.exs
+++ b/test/xdr/contract/sc_status_test.exs
@@ -3,7 +3,6 @@ defmodule StellarBase.XDR.SCStatusTest do
 
   alias StellarBase.XDR.SCStatus
   alias StellarBase.XDR.SCStatusType
-  alias StellarBase.XDR.SCStatusTest
 
   alias StellarBase.XDR.{
     SCUnknownErrorCode,
@@ -18,8 +17,6 @@ defmodule StellarBase.XDR.SCStatusTest do
     UInt32,
     Void
   }
-
-  alias StellarBase.StrKey
 
   describe "SCStatus" do
     setup do

--- a/test/xdr/contract/sc_val_test.exs
+++ b/test/xdr/contract/sc_val_test.exs
@@ -4,11 +4,11 @@ defmodule StellarBase.XDR.SCValTest do
   alias StellarBase.XDR.{
     Int64,
     Int32,
+    OptionalSCObject,
     UInt32,
     UInt64,
     SCValType,
     SCStatic,
-    # SCV_OBJECT,
     SCStatus,
     SCStatusType,
     SCUnknownErrorCode,
@@ -40,11 +40,11 @@ defmodule StellarBase.XDR.SCValTest do
           sc_code: SCStatic.new(:SCS_TRUE),
           binary: <<0, 0, 0, 3, 0, 0, 0, 1>>
         },
-        #  %{
-        #   val_type: SCValType.new(:SCV_OBJECT),
-        #   sc_code: UInt32.new(3),
-        #   binary: <<0, 0, 0, 4, 0, 0, 0, 3>>
-        # },
+        %{
+          val_type: SCValType.new(:SCV_OBJECT),
+          sc_code: OptionalSCObject.new(nil),
+          binary: <<0, 0, 0, 4, 0, 0, 0, 0>>
+        },
         %{
           val_type: SCValType.new(:SCV_SYMBOL),
           sc_code: SCSymbol.new("World"),

--- a/test/xdr/contract/sc_val_test.exs
+++ b/test/xdr/contract/sc_val_test.exs
@@ -1,0 +1,110 @@
+defmodule StellarBase.XDR.SCValTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    Int64,
+    Int32,
+    UInt32,
+    UInt64,
+    SCValType,
+    SCStatic,
+    # SCV_OBJECT,
+    SCStatus,
+    SCStatusType,
+    SCUnknownErrorCode,
+    SCSymbol,
+    SCVal,
+    SCValType
+  }
+
+  describe "SCVal" do
+    setup do
+      discriminants = [
+        %{
+          val_type: SCValType.new(:SCV_U63),
+          sc_code: Int64.new(2),
+          binary: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2>>
+        },
+        %{
+          val_type: SCValType.new(:SCV_U32),
+          sc_code: UInt32.new(2),
+          binary: <<0, 0, 0, 1, 0, 0, 0, 2>>
+        },
+        %{
+          val_type: SCValType.new(:SCV_I32),
+          sc_code: Int32.new(3),
+          binary: <<0, 0, 0, 2, 0, 0, 0, 3>>
+        },
+        %{
+          val_type: SCValType.new(:SCV_STATIC),
+          sc_code: SCStatic.new(:SCS_TRUE),
+          binary: <<0, 0, 0, 3, 0, 0, 0, 1>>
+        },
+        #  %{
+        #   val_type: SCValType.new(:SCV_OBJECT),
+        #   sc_code: UInt32.new(3),
+        #   binary: <<0, 0, 0, 4, 0, 0, 0, 3>>
+        # },
+        %{
+          val_type: SCValType.new(:SCV_SYMBOL),
+          sc_code: SCSymbol.new("World"),
+          binary: <<0, 0, 0, 5, 0, 0, 0, 5, 87, 111, 114, 108, 100, 0, 0, 0>>
+        },
+        %{
+          val_type: SCValType.new(:SCV_BITSET),
+          sc_code: UInt64.new(4),
+          binary: <<0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 4>>
+        },
+        %{
+          val_type: SCValType.new(:SCV_STATUS),
+          sc_code:
+            SCStatus.new(
+              SCUnknownErrorCode.new(:UNKNOWN_ERROR_GENERAL),
+              SCStatusType.new(:SST_UNKNOWN_ERROR)
+            ),
+          binary: <<0, 0, 0, 7, 0, 0, 0, 1, 0, 0, 0, 0>>
+        }
+      ]
+
+      %{discriminants: discriminants}
+    end
+
+    test "new/1", %{discriminants: discriminants} do
+      for %{val_type: val_type, sc_code: sc_code} <- discriminants do
+        %SCVal{code: ^sc_code, type: ^val_type} = SCVal.new(sc_code, val_type)
+      end
+    end
+
+    test "encode_xdr/1", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, val_type: val_type, binary: binary} <- discriminants do
+        xdr = SCVal.new(sc_code, val_type)
+        {:ok, ^binary} = SCVal.encode_xdr(xdr)
+      end
+    end
+
+    test "encode_xdr!/1", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, val_type: val_type, binary: binary} <- discriminants do
+        xdr = SCVal.new(sc_code, val_type)
+        ^binary = SCVal.encode_xdr!(xdr)
+      end
+    end
+
+    test "decode_xdr/2", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, val_type: val_type, binary: binary} <- discriminants do
+        xdr = SCVal.new(sc_code, val_type)
+        {:ok, {^xdr, ""}} = SCVal.decode_xdr(binary)
+      end
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCVal.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, val_type: val_type, binary: binary} <- discriminants do
+        xdr = SCVal.new(sc_code, val_type)
+        {^xdr, ""} = SCVal.decode_xdr!(binary)
+      end
+    end
+  end
+end

--- a/test/xdr/contract/sc_val_test.exs
+++ b/test/xdr/contract/sc_val_test.exs
@@ -22,42 +22,42 @@ defmodule StellarBase.XDR.SCValTest do
       discriminants = [
         %{
           val_type: SCValType.new(:SCV_U63),
-          sc_code: Int64.new(2),
+          value: Int64.new(2),
           binary: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2>>
         },
         %{
           val_type: SCValType.new(:SCV_U32),
-          sc_code: UInt32.new(2),
+          value: UInt32.new(2),
           binary: <<0, 0, 0, 1, 0, 0, 0, 2>>
         },
         %{
           val_type: SCValType.new(:SCV_I32),
-          sc_code: Int32.new(3),
+          value: Int32.new(3),
           binary: <<0, 0, 0, 2, 0, 0, 0, 3>>
         },
         %{
           val_type: SCValType.new(:SCV_STATIC),
-          sc_code: SCStatic.new(:SCS_TRUE),
+          value: SCStatic.new(:SCS_TRUE),
           binary: <<0, 0, 0, 3, 0, 0, 0, 1>>
         },
         %{
           val_type: SCValType.new(:SCV_OBJECT),
-          sc_code: OptionalSCObject.new(nil),
+          value: OptionalSCObject.new(nil),
           binary: <<0, 0, 0, 4, 0, 0, 0, 0>>
         },
         %{
           val_type: SCValType.new(:SCV_SYMBOL),
-          sc_code: SCSymbol.new("World"),
+          value: SCSymbol.new("World"),
           binary: <<0, 0, 0, 5, 0, 0, 0, 5, 87, 111, 114, 108, 100, 0, 0, 0>>
         },
         %{
           val_type: SCValType.new(:SCV_BITSET),
-          sc_code: UInt64.new(4),
+          value: UInt64.new(4),
           binary: <<0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 4>>
         },
         %{
           val_type: SCValType.new(:SCV_STATUS),
-          sc_code:
+          value:
             SCStatus.new(
               SCUnknownErrorCode.new(:UNKNOWN_ERROR_GENERAL),
               SCStatusType.new(:SST_UNKNOWN_ERROR)
@@ -70,28 +70,28 @@ defmodule StellarBase.XDR.SCValTest do
     end
 
     test "new/1", %{discriminants: discriminants} do
-      for %{val_type: val_type, sc_code: sc_code} <- discriminants do
-        %SCVal{code: ^sc_code, type: ^val_type} = SCVal.new(sc_code, val_type)
+      for %{val_type: val_type, value: value} <- discriminants do
+        %SCVal{value: ^value, type: ^val_type} = SCVal.new(value, val_type)
       end
     end
 
     test "encode_xdr/1", %{discriminants: discriminants} do
-      for %{sc_code: sc_code, val_type: val_type, binary: binary} <- discriminants do
-        xdr = SCVal.new(sc_code, val_type)
+      for %{value: value, val_type: val_type, binary: binary} <- discriminants do
+        xdr = SCVal.new(value, val_type)
         {:ok, ^binary} = SCVal.encode_xdr(xdr)
       end
     end
 
     test "encode_xdr!/1", %{discriminants: discriminants} do
-      for %{sc_code: sc_code, val_type: val_type, binary: binary} <- discriminants do
-        xdr = SCVal.new(sc_code, val_type)
+      for %{value: value, val_type: val_type, binary: binary} <- discriminants do
+        xdr = SCVal.new(value, val_type)
         ^binary = SCVal.encode_xdr!(xdr)
       end
     end
 
     test "decode_xdr/2", %{discriminants: discriminants} do
-      for %{sc_code: sc_code, val_type: val_type, binary: binary} <- discriminants do
-        xdr = SCVal.new(sc_code, val_type)
+      for %{value: value, val_type: val_type, binary: binary} <- discriminants do
+        xdr = SCVal.new(value, val_type)
         {:ok, {^xdr, ""}} = SCVal.decode_xdr(binary)
       end
     end
@@ -101,8 +101,8 @@ defmodule StellarBase.XDR.SCValTest do
     end
 
     test "decode_xdr!/2", %{discriminants: discriminants} do
-      for %{sc_code: sc_code, val_type: val_type, binary: binary} <- discriminants do
-        xdr = SCVal.new(sc_code, val_type)
+      for %{value: value, val_type: val_type, binary: binary} <- discriminants do
+        xdr = SCVal.new(value, val_type)
         {^xdr, ""} = SCVal.decode_xdr!(binary)
       end
     end

--- a/test/xdr/contract/sc_vec_test.exs
+++ b/test/xdr/contract/sc_vec_test.exs
@@ -1,0 +1,50 @@
+# defmodule StellarBase.XDR.SCVecTest do
+#   use ExUnit.Case
+
+#   alias StellarBase.XDR.{
+#     SCVec
+#   }
+
+#   describe "SCVec" do
+#     setup do
+#       claimants_list = [claimant1, claimant2]
+
+#       %{
+#         claimants_list: claimants_list,
+#         claimants: SCVec.new(claimants_list),
+#         binary: nil
+#       }
+#     end
+
+#     test "new/1", %{claimants_list: claimants_list} do
+#       %SCVec{claimants: ^claimants_list} = SCVec.new(claimants_list)
+#     end
+
+#     test "encode_xdr/1", %{claimants: claimants, binary: binary} do
+#       {:ok, ^binary} = SCVec.encode_xdr(claimants)
+#     end
+
+#     test "encode_xdr/1 with invalid elements" do
+#       {:error, :not_list} =
+#         %{elements: nil}
+#         |> SCVec.new()
+#         |> SCVec.encode_xdr()
+#     end
+
+#     test "encode_xdr!/1", %{claimants: claimants, binary: binary} do
+#       ^binary = SCVec.encode_xdr!(claimants)
+#     end
+
+#     test "decode_xdr/2", %{claimants: claimants, binary: binary} do
+#       {:ok, {^claimants, ""}} = SCVec.decode_xdr(binary)
+#     end
+
+#     test "decode_xdr/2 with an invalid binary" do
+#       {:error, :not_binary} = SCVec.decode_xdr(123)
+#     end
+
+#     test "decode_xdr!/2", %{claimants: claimants, binary: binary} do
+#       {^claimants, ^binary} = SCVec.decode_xdr!(binary <> binary)
+#     end
+#   end
+# end

--- a/test/xdr/contract/sc_vec_test.exs
+++ b/test/xdr/contract/sc_vec_test.exs
@@ -1,50 +1,57 @@
-# defmodule StellarBase.XDR.SCVecTest do
-#   use ExUnit.Case
+defmodule StellarBase.XDR.SCVecTest do
+  use ExUnit.Case
 
-#   alias StellarBase.XDR.{
-#     SCVec
-#   }
+  alias StellarBase.XDR.{
+    SCVec,
+    SCVal,
+    SCValType,
+    Int64
+  }
 
-#   describe "SCVec" do
-#     setup do
-#       claimants_list = [claimant1, claimant2]
+  describe "SCVec" do
+    setup do
+      scval1 = SCVal.new(Int64.new(3), SCValType.new(:SCV_U63))
+      scval2 = SCVal.new(Int64.new(2), SCValType.new(:SCV_U63))
 
-#       %{
-#         claimants_list: claimants_list,
-#         claimants: SCVec.new(claimants_list),
-#         binary: nil
-#       }
-#     end
+      scvals = [scval1, scval2]
 
-#     test "new/1", %{claimants_list: claimants_list} do
-#       %SCVec{claimants: ^claimants_list} = SCVec.new(claimants_list)
-#     end
+      %{
+        scvals: scvals,
+        scvec: SCVec.new(scvals),
+        binary:
+          <<0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2>>
+      }
+    end
 
-#     test "encode_xdr/1", %{claimants: claimants, binary: binary} do
-#       {:ok, ^binary} = SCVec.encode_xdr(claimants)
-#     end
+    test "new/1", %{scvals: scvals} do
+      %SCVec{scvals: ^scvals} = SCVec.new(scvals)
+    end
 
-#     test "encode_xdr/1 with invalid elements" do
-#       {:error, :not_list} =
-#         %{elements: nil}
-#         |> SCVec.new()
-#         |> SCVec.encode_xdr()
-#     end
+    test "encode_xdr/1", %{scvec: scvec, binary: binary} do
+      {:ok, ^binary} = SCVec.encode_xdr(scvec)
+    end
 
-#     test "encode_xdr!/1", %{claimants: claimants, binary: binary} do
-#       ^binary = SCVec.encode_xdr!(claimants)
-#     end
+    test "encode_xdr/1 with invalid elements" do
+      {:error, :not_list} =
+        %{elements: nil}
+        |> SCVec.new()
+        |> SCVec.encode_xdr()
+    end
 
-#     test "decode_xdr/2", %{claimants: claimants, binary: binary} do
-#       {:ok, {^claimants, ""}} = SCVec.decode_xdr(binary)
-#     end
+    test "encode_xdr!/1", %{scvec: scvec, binary: binary} do
+      ^binary = SCVec.encode_xdr!(scvec)
+    end
 
-#     test "decode_xdr/2 with an invalid binary" do
-#       {:error, :not_binary} = SCVec.decode_xdr(123)
-#     end
+    test "decode_xdr/2", %{scvec: scvec, binary: binary} do
+      {:ok, {^scvec, ""}} = SCVec.decode_xdr(binary)
+    end
 
-#     test "decode_xdr!/2", %{claimants: claimants, binary: binary} do
-#       {^claimants, ^binary} = SCVec.decode_xdr!(binary <> binary)
-#     end
-#   end
-# end
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCVec.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{scvec: scvec, binary: binary} do
+      {^scvec, ^binary} = SCVec.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/sc_vec_test.exs
+++ b/test/xdr/contract/sc_vec_test.exs
@@ -13,18 +13,18 @@ defmodule StellarBase.XDR.SCVecTest do
       scval1 = SCVal.new(Int64.new(3), SCValType.new(:SCV_U63))
       scval2 = SCVal.new(Int64.new(2), SCValType.new(:SCV_U63))
 
-      scvals = [scval1, scval2]
+      sc_vals = [scval1, scval2]
 
       %{
-        scvals: scvals,
-        scvec: SCVec.new(scvals),
+        sc_vals: sc_vals,
+        scvec: SCVec.new(sc_vals),
         binary:
           <<0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2>>
       }
     end
 
-    test "new/1", %{scvals: scvals} do
-      %SCVec{scvals: ^scvals} = SCVec.new(scvals)
+    test "new/1", %{sc_vals: sc_vals} do
+      %SCVec{sc_vals: ^sc_vals} = SCVec.new(sc_vals)
     end
 
     test "encode_xdr/1", %{scvec: scvec, binary: binary} do

--- a/test/xdr/types/variable_opaque256000_test.exs
+++ b/test/xdr/types/variable_opaque256000_test.exs
@@ -1,0 +1,51 @@
+defmodule StellarBase.XDR.VariableOpaque256000Test do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.VariableOpaque256000
+
+  describe "VariableOpaque256000" do
+    setup do
+      %{
+        variable_opaque256000: VariableOpaque256000.new("GCIZ3GSM5"),
+        binary: <<0, 0, 0, 9, 71, 67, 73, 90, 51, 71, 83, 77, 53, 0, 0, 0>>
+      }
+    end
+
+    test "new/1" do
+      %VariableOpaque256000{opaque: variable_opaque256000} =
+        VariableOpaque256000.new(<<0, 0, 0, 9, 71, 67, 73, 90, 51, 71, 83, 77, 53, 0, 0, 0>>)
+
+      16 = String.length(variable_opaque256000)
+    end
+
+    test "encode_xdr/1", %{variable_opaque256000: variable_opaque256000, binary: binary} do
+      {:ok, ^binary} = VariableOpaque256000.encode_xdr(variable_opaque256000)
+    end
+
+    test "encode_xdr!/1", %{variable_opaque256000: variable_opaque256000, binary: binary} do
+      ^binary = VariableOpaque256000.encode_xdr!(variable_opaque256000)
+    end
+
+    test "decode_xdr/2", %{variable_opaque256000: variable_opaque256000, binary: binary} do
+      {:ok, {^variable_opaque256000, ""}} = VariableOpaque256000.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = VariableOpaque256000.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{variable_opaque256000: variable_opaque256000, binary: binary} do
+      {^variable_opaque256000, ""} = VariableOpaque256000.decode_xdr!(binary)
+    end
+
+    test "invalid length" do
+      bits = 256_001 * 8
+      binary = <<0::size(bits)>>
+
+      {:error, :invalid_length} =
+        VariableOpaque256000.encode_xdr(%VariableOpaque256000{
+          opaque: binary
+        })
+    end
+  end
+end


### PR DESCRIPTION
Contributing to #224 

In this PR, the following types were added:

- SCStatus
- SCObject
- OptionalSCObject
- VariableOpaque256000
- SCVal
- SCObjectType
- SCMapEntry
- SCVec<SCVAL_LIMIT>
- SCMap<SCVAL_LIMIT>
- SCContractCodeType
- SCContractCode
- Int128Parts
- SCAddressType
- SCAddress