### PR TITLE
Contract Spec XDR types - Part 3

### DIFF
--- a/lib/xdr/contract/spec/sc_spec_function_input_v0.ex
+++ b/lib/xdr/contract/spec/sc_spec_function_input_v0.ex
@@ -1,0 +1,60 @@
+defmodule StellarBase.XDR.SCSpecFunctionInputV0 do
+  @moduledoc """
+  Representation of Stellar `SCSpecFunctionInputV0` type.
+  """
+
+  alias StellarBase.XDR.{SCSpecTypeDef, String30, String1024}
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(doc: String1024, name: String30, type: SCSpecTypeDef)
+
+  @type doc :: String1024.t()
+  @type name :: String30.t()
+  @type type :: SCSpecTypeDef.t()
+
+  @type t :: %__MODULE__{doc: doc(), name: name(), type: type()}
+
+  defstruct [:doc, :name, :type]
+
+  @spec new(doc :: String1024.t(), name :: String30.t(), type :: SCSpecTypeDef.t()) :: t()
+  def new(%String1024{} = doc, %String30{} = name, %SCSpecTypeDef{} = type),
+    do: %__MODULE__{doc: doc, name: name, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{doc: doc, name: name, type: type}) do
+    [doc: doc, name: name, type: type]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{doc: doc, name: name, type: type}) do
+    [doc: doc, name: name, type: type]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [doc: doc, name: name, type: type]}, rest}} ->
+        {:ok, {new(doc, name, type), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [doc: doc, name: name, type: type]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(doc, name, type), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_function_input_v0.ex
+++ b/lib/xdr/contract/spec/sc_spec_function_input_v0.ex
@@ -17,7 +17,7 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0 do
 
   defstruct [:doc, :name, :type]
 
-  @spec new(doc :: String1024.t(), name :: String30.t(), type :: SCSpecTypeDef.t()) :: t()
+  @spec new(doc :: doc(), name :: name(), type :: type()) :: t()
   def new(%String1024{} = doc, %String30{} = name, %SCSpecTypeDef{} = type),
     do: %__MODULE__{doc: doc, name: name, type: type}
 

--- a/lib/xdr/contract/spec/sc_spec_function_input_v0_list.ex
+++ b/lib/xdr/contract/spec/sc_spec_function_input_v0_list.ex
@@ -13,24 +13,24 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0List do
 
   @array_spec %{type: @array_type, max_length: @max_length}
 
-  @type t :: %__MODULE__{input_list: list(SCSpecFunctionInputV0.t())}
+  @type t :: %__MODULE__{inputs: list(SCSpecFunctionInputV0.t())}
 
-  defstruct [:input_list]
+  defstruct [:inputs]
 
-  @spec new(input_list :: list(SCSpecTypeDef.t())) :: t()
-  def new(input_list),
-    do: %__MODULE__{input_list: input_list}
+  @spec new(inputs :: list(SCSpecFunctionInputV0.t())) :: t()
+  def new(inputs),
+    do: %__MODULE__{inputs: inputs}
 
   @impl true
-  def encode_xdr(%__MODULE__{input_list: input_list}) do
-    input_list
+  def encode_xdr(%__MODULE__{inputs: inputs}) do
+    inputs
     |> XDR.VariableArray.new(@array_type, @max_length)
     |> XDR.VariableArray.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{input_list: input_list}) do
-    input_list
+  def encode_xdr!(%__MODULE__{inputs: inputs}) do
+    inputs
     |> XDR.VariableArray.new(@array_type, @max_length)
     |> XDR.VariableArray.encode_xdr!()
   end
@@ -40,8 +40,8 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0List do
 
   def decode_xdr(bytes, spec) do
     case XDR.VariableArray.decode_xdr(bytes, spec) do
-      {:ok, {input_list, rest}} ->
-        {:ok, {new(input_list), rest}}
+      {:ok, {inputs, rest}} ->
+        {:ok, {new(inputs), rest}}
 
       error ->
         error
@@ -52,7 +52,7 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0List do
   def decode_xdr!(bytes, spec \\ @array_spec)
 
   def decode_xdr!(bytes, spec) do
-    {input_list, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
-    {new(input_list), rest}
+    {inputs, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(inputs), rest}
   end
 end

--- a/lib/xdr/contract/spec/sc_spec_function_input_v0_list.ex
+++ b/lib/xdr/contract/spec/sc_spec_function_input_v0_list.ex
@@ -1,0 +1,58 @@
+defmodule StellarBase.XDR.SCSpecFunctionInputV0List do
+  @moduledoc """
+  Representation of a Stellar `SCSpecFunctionInputV0List` list.
+  """
+
+  alias StellarBase.XDR.SCSpecFunctionInputV0
+
+  @behaviour XDR.Declaration
+
+  @max_length 10
+
+  @array_type SCSpecFunctionInputV0
+
+  @array_spec %{type: @array_type, max_length: @max_length}
+
+  @type t :: %__MODULE__{input_list: list(SCSpecFunctionInputV0.t())}
+
+  defstruct [:input_list]
+
+  @spec new(input_list :: list(SCSpecTypeDef.t())) :: t()
+  def new(input_list),
+    do: %__MODULE__{input_list: input_list}
+
+  @impl true
+  def encode_xdr(%__MODULE__{input_list: input_list}) do
+    input_list
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{input_list: input_list}) do
+    input_list
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @array_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.VariableArray.decode_xdr(bytes, spec) do
+      {:ok, {input_list, rest}} ->
+        {:ok, {new(input_list), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @array_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {input_list, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(input_list), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_function_v0.ex
+++ b/lib/xdr/contract/spec/sc_spec_function_v0.ex
@@ -29,12 +29,6 @@ defmodule StellarBase.XDR.SCSpecFunctionV0 do
   defstruct [:doc, :name, :inputs, :outputs]
 
   @spec new(doc :: doc(), name :: name(), inputs :: inputs(), outputs: outputs()) :: t()
-  @spec new(
-          StellarBase.XDR.String1024.t(),
-          StellarBase.XDR.SCSymbol.t(),
-          StellarBase.XDR.SCSpecFunctionInputV0List.t(),
-          StellarBase.XDR.SCSpecTypeDef1.t()
-        ) :: StellarBase.XDR.SCSpecFunctionV0.t()
   def new(
         %String1024{} = doc,
         %SCSymbol{} = name,

--- a/lib/xdr/contract/spec/sc_spec_function_v0.ex
+++ b/lib/xdr/contract/spec/sc_spec_function_v0.ex
@@ -28,9 +28,7 @@ defmodule StellarBase.XDR.SCSpecFunctionV0 do
 
   defstruct [:doc, :name, :inputs, :outputs]
 
-  @spec new(doc :: String1024.t(), name :: SCSymbol.t(), inputs :: SCSpecFunctionInputV0List.t(),
-          outputs: SCSpecTypeDef1.t()
-        ) :: t()
+  @spec new(doc :: doc(), name :: name(), inputs :: inputs(), outputs: outputs()) :: t()
   @spec new(
           StellarBase.XDR.String1024.t(),
           StellarBase.XDR.SCSymbol.t(),

--- a/lib/xdr/contract/spec/sc_spec_function_v0.ex
+++ b/lib/xdr/contract/spec/sc_spec_function_v0.ex
@@ -1,0 +1,85 @@
+defmodule StellarBase.XDR.SCSpecFunctionV0 do
+  @moduledoc """
+  Representation of Stellar `SCSpecFunctionV0` type.
+  """
+
+  alias StellarBase.XDR.{SCSpecTypeDef1, String1024, SCSymbol, SCSpecFunctionInputV0List}
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(
+                 doc: String1024,
+                 name: SCSymbol,
+                 inputs: SCSpecFunctionInputV0List,
+                 outputs: SCSpecTypeDef1
+               )
+
+  @type doc :: String1024.t()
+  @type name :: SCSymbol.t()
+  @type inputs :: SCSpecFunctionInputV0List.t()
+  @type outputs :: SCSpecTypeDef1.t()
+
+  @type t :: %__MODULE__{
+          doc: doc(),
+          name: name(),
+          inputs: inputs(),
+          outputs: outputs()
+        }
+
+  defstruct [:doc, :name, :inputs, :outputs]
+
+  @spec new(doc :: String1024.t(), name :: SCSymbol.t(), inputs :: SCSpecFunctionInputV0List.t(),
+          outputs: SCSpecTypeDef1.t()
+        ) :: t()
+  @spec new(
+          StellarBase.XDR.String1024.t(),
+          StellarBase.XDR.SCSymbol.t(),
+          StellarBase.XDR.SCSpecFunctionInputV0List.t(),
+          StellarBase.XDR.SCSpecTypeDef1.t()
+        ) :: StellarBase.XDR.SCSpecFunctionV0.t()
+  def new(
+        %String1024{} = doc,
+        %SCSymbol{} = name,
+        %SCSpecFunctionInputV0List{} = inputs,
+        %SCSpecTypeDef1{} = outputs
+      ),
+      do: %__MODULE__{doc: doc, name: name, inputs: inputs, outputs: outputs}
+
+  @impl true
+  def encode_xdr(%__MODULE__{doc: doc, name: name, inputs: inputs, outputs: outputs}) do
+    [doc: doc, name: name, inputs: inputs, outputs: outputs]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{doc: doc, name: name, inputs: inputs, outputs: outputs}) do
+    [doc: doc, name: name, inputs: inputs, outputs: outputs]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok,
+       {%XDR.Struct{components: [doc: doc, name: name, inputs: inputs, outputs: outputs]}, rest}} ->
+        {:ok, {new(doc, name, inputs, outputs), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [doc: doc, name: name, inputs: inputs, outputs: outputs]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(doc, name, inputs, outputs), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_def.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_def.ex
@@ -1,0 +1,101 @@
+defmodule StellarBase.XDR.SCSpecTypeDef do
+  @moduledoc """
+  Representation of Stellar `SCSpecTypeDef` type.
+  """
+
+  alias StellarBase.XDR.{
+    SCSpecType,
+    SCSpecTypeVec,
+    SCSpecTypeMap,
+    SCSpecTypeSet,
+    SCSpecTypeTuple,
+    SCSpecTypeBytesN,
+    SCSpecTypeUDT,
+    SCSpecTypeOption,
+    SCSpecTypeResult,
+    Void
+  }
+
+  @behaviour XDR.Declaration
+
+  @arms [
+    SC_SPEC_TYPE_VAL: Void,
+    SC_SPEC_TYPE_U64: Void,
+    SC_SPEC_TYPE_I64: Void,
+    SC_SPEC_TYPE_U128: Void,
+    SC_SPEC_TYPE_I128: Void,
+    SC_SPEC_TYPE_U32: Void,
+    SC_SPEC_TYPE_I32: Void,
+    SC_SPEC_TYPE_BOOL: Void,
+    SC_SPEC_TYPE_SYMBOL: Void,
+    SC_SPEC_TYPE_BITSET: Void,
+    SC_SPEC_TYPE_STATUS: Void,
+    SC_SPEC_TYPE_BYTES: Void,
+    SC_SPEC_TYPE_ADDRESS: Void,
+    SC_SPEC_TYPE_OPTION: SCSpecTypeOption,
+    SC_SPEC_TYPE_RESULT: SCSpecTypeResult,
+    SC_SPEC_TYPE_VEC: SCSpecTypeVec,
+    SC_SPEC_TYPE_MAP: SCSpecTypeMap,
+    SC_SPEC_TYPE_SET: SCSpecTypeSet,
+    SC_SPEC_TYPE_TUPLE: SCSpecTypeTuple,
+    SC_SPEC_TYPE_BYTES_N: SCSpecTypeBytesN,
+    SC_SPEC_TYPE_UDT: SCSpecTypeUDT
+  ]
+
+  @type code ::
+          SCSpecTypeVec
+          | SCSpecTypeMap
+          | SCSpecTypeSet
+          | SCSpecTypeTuple
+          | SCSpecTypeBytesN
+          | SCSpecTypeUDT
+          | SCSpecTypeOption
+          | SCSpecTypeResult
+          | Void
+
+  @type t :: %__MODULE__{code: code(), type: SCSpecType.t()}
+
+  defstruct [:code, :type]
+
+  @spec new(code :: code(), type :: SCSpecType.t()) :: t()
+  def new(code, %SCSpecType{} = type), do: %__MODULE__{code: code, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{code: code, type: type}) do
+    type
+    |> XDR.Union.new(@arms, code)
+    |> XDR.Union.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{code: code, type: type}) do
+    type
+    |> XDR.Union.new(@arms, code)
+    |> XDR.Union.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ union_spec())
+
+  def decode_xdr(bytes, spec) do
+    case XDR.Union.decode_xdr(bytes, spec) do
+      {:ok, {{type, code}, rest}} -> {:ok, {new(code, type), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ union_spec())
+
+  def decode_xdr!(bytes, spec) do
+    {{type, code}, rest} = XDR.Union.decode_xdr!(bytes, spec)
+    {new(code, type), rest}
+  end
+
+  @spec union_spec() :: XDR.Union.t()
+  defp union_spec do
+    nil
+    |> SCSpecType.new()
+    |> XDR.Union.new(@arms)
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_def.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_def.ex
@@ -43,21 +43,23 @@ defmodule StellarBase.XDR.SCSpecTypeDef do
   ]
 
   @type code ::
-          SCSpecTypeVec
-          | SCSpecTypeMap
-          | SCSpecTypeSet
-          | SCSpecTypeTuple
-          | SCSpecTypeBytesN
-          | SCSpecTypeUDT
-          | SCSpecTypeOption
-          | SCSpecTypeResult
-          | Void
+          SCSpecTypeVec.t()
+          | SCSpecTypeMap.t()
+          | SCSpecTypeSet.t()
+          | SCSpecTypeTuple.t()
+          | SCSpecTypeBytesN.t()
+          | SCSpecTypeUDT.t()
+          | SCSpecTypeOption.t()
+          | SCSpecTypeResult.t()
+          | Void.t()
 
-  @type t :: %__MODULE__{code: code(), type: SCSpecType.t()}
+  @type type :: SCSpecType.t()
+
+  @type t :: %__MODULE__{code: code(), type: type()}
 
   defstruct [:code, :type]
 
-  @spec new(code :: code(), type :: SCSpecType.t()) :: t()
+  @spec new(code :: code(), type :: type()) :: t()
   def new(code, %SCSpecType{} = type), do: %__MODULE__{code: code, type: type}
 
   @impl true

--- a/lib/xdr/contract/spec/sc_spec_type_def1.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_def1.ex
@@ -1,0 +1,55 @@
+defmodule StellarBase.XDR.SCSpecTypeDef1 do
+  @moduledoc """
+  Representation of a Stellar `SCSpecTypeDef` list.
+  """
+
+  alias StellarBase.XDR.SCSpecTypeDef
+
+  @behaviour XDR.Declaration
+
+  @max_length 1
+
+  @array_type SCSpecTypeDef
+
+  @array_spec %{type: @array_type, max_length: @max_length}
+
+  @type t :: %__MODULE__{sc_spec_type_defs: list(SCSpecTypeDef.t())}
+
+  defstruct [:sc_spec_type_defs]
+
+  @spec new(sc_spec_type_defs :: list(SCSpecTypeDef.t())) :: t()
+  def new(sc_spec_type_defs),
+    do: %__MODULE__{sc_spec_type_defs: sc_spec_type_defs}
+
+  @impl true
+  def encode_xdr(%__MODULE__{sc_spec_type_defs: sc_spec_type_defs}) do
+    sc_spec_type_defs
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{sc_spec_type_defs: sc_spec_type_defs}) do
+    sc_spec_type_defs
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @array_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.VariableArray.decode_xdr(bytes, spec) do
+      {:ok, {sc_spec_type_defs, rest}} -> {:ok, {new(sc_spec_type_defs), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @array_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {sc_spec_type_defs, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(sc_spec_type_defs), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_def12.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_def12.ex
@@ -1,0 +1,55 @@
+defmodule StellarBase.XDR.SCSpecTypeDef12 do
+  @moduledoc """
+  Representation of a Stellar `SCSpecTypeDef` list.
+  """
+
+  alias StellarBase.XDR.SCSpecTypeDef
+
+  @behaviour XDR.Declaration
+
+  @max_length 12
+
+  @array_type SCSpecTypeDef
+
+  @array_spec %{type: @array_type, max_length: @max_length}
+
+  @type t :: %__MODULE__{sc_spec_type_defs: list(SCSpecTypeDef.t())}
+
+  defstruct [:sc_spec_type_defs]
+
+  @spec new(sc_spec_type_defs :: list(SCSpecTypeDef.t())) :: t()
+  def new(sc_spec_type_defs),
+    do: %__MODULE__{sc_spec_type_defs: sc_spec_type_defs}
+
+  @impl true
+  def encode_xdr(%__MODULE__{sc_spec_type_defs: sc_spec_type_defs}) do
+    sc_spec_type_defs
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{sc_spec_type_defs: sc_spec_type_defs}) do
+    sc_spec_type_defs
+    |> XDR.VariableArray.new(@array_type, @max_length)
+    |> XDR.VariableArray.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, spec \\ @array_spec)
+
+  def decode_xdr(bytes, spec) do
+    case XDR.VariableArray.decode_xdr(bytes, spec) do
+      {:ok, {sc_spec_type_defs, rest}} -> {:ok, {new(sc_spec_type_defs), rest}}
+      error -> error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, spec \\ @array_spec)
+
+  def decode_xdr!(bytes, spec) do
+    {sc_spec_type_defs, rest} = XDR.VariableArray.decode_xdr!(bytes, spec)
+    {new(sc_spec_type_defs), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_map.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_map.ex
@@ -1,0 +1,59 @@
+defmodule StellarBase.XDR.SCSpecTypeMap do
+  @moduledoc """
+  Representation of Stellar `SCSpecTypeMap` type.
+  """
+
+  alias StellarBase.XDR.SCSpecTypeDef
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(keyType: SCSpecTypeDef, valueType: SCSpecTypeDef)
+
+  @type keyType :: SCSpecTypeDef.t()
+  @type valueType :: SCSpecTypeDef.t()
+
+  @type t :: %__MODULE__{keyType: keyType(), valueType: valueType()}
+
+  defstruct [:keyType, :valueType]
+
+  @spec new(keyType :: SCSpecTypeDef.t(), valueType :: SCSpecTypeDef.t()) :: t()
+  def new(%SCSpecTypeDef{} = keyType, %SCSpecTypeDef{} = valueType),
+    do: %__MODULE__{keyType: keyType, valueType: valueType}
+
+  @impl true
+  def encode_xdr(%__MODULE__{keyType: keyType, valueType: valueType}) do
+    [keyType: keyType, valueType: valueType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{keyType: keyType, valueType: valueType}) do
+    [keyType: keyType, valueType: valueType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [keyType: keyType, valueType: valueType]}, rest}} ->
+        {:ok, {new(keyType, valueType), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [keyType: keyType, valueType: valueType]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(keyType, valueType), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_map.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_map.ex
@@ -7,29 +7,29 @@ defmodule StellarBase.XDR.SCSpecTypeMap do
 
   @behaviour XDR.Declaration
 
-  @struct_spec XDR.Struct.new(keyType: SCSpecTypeDef, valueType: SCSpecTypeDef)
+  @struct_spec XDR.Struct.new(key_type: SCSpecTypeDef, value_type: SCSpecTypeDef)
 
-  @type keyType :: SCSpecTypeDef.t()
-  @type valueType :: SCSpecTypeDef.t()
+  @type key_type :: SCSpecTypeDef.t()
+  @type value_type :: SCSpecTypeDef.t()
 
-  @type t :: %__MODULE__{keyType: keyType(), valueType: valueType()}
+  @type t :: %__MODULE__{key_type: key_type(), value_type: value_type()}
 
-  defstruct [:keyType, :valueType]
+  defstruct [:key_type, :value_type]
 
-  @spec new(keyType :: SCSpecTypeDef.t(), valueType :: SCSpecTypeDef.t()) :: t()
-  def new(%SCSpecTypeDef{} = keyType, %SCSpecTypeDef{} = valueType),
-    do: %__MODULE__{keyType: keyType, valueType: valueType}
+  @spec new(key_type :: key_type(), value_type :: value_type()) :: t()
+  def new(%SCSpecTypeDef{} = key_type, %SCSpecTypeDef{} = value_type),
+    do: %__MODULE__{key_type: key_type, value_type: value_type}
 
   @impl true
-  def encode_xdr(%__MODULE__{keyType: keyType, valueType: valueType}) do
-    [keyType: keyType, valueType: valueType]
+  def encode_xdr(%__MODULE__{key_type: key_type, value_type: value_type}) do
+    [key_type: key_type, value_type: value_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{keyType: keyType, valueType: valueType}) do
-    [keyType: keyType, valueType: valueType]
+  def encode_xdr!(%__MODULE__{key_type: key_type, value_type: value_type}) do
+    [key_type: key_type, value_type: value_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr!()
   end
@@ -39,8 +39,8 @@ defmodule StellarBase.XDR.SCSpecTypeMap do
 
   def decode_xdr(bytes, struct) do
     case XDR.Struct.decode_xdr(bytes, struct) do
-      {:ok, {%XDR.Struct{components: [keyType: keyType, valueType: valueType]}, rest}} ->
-        {:ok, {new(keyType, valueType), rest}}
+      {:ok, {%XDR.Struct{components: [key_type: key_type, value_type: value_type]}, rest}} ->
+        {:ok, {new(key_type, value_type), rest}}
 
       error ->
         error
@@ -51,9 +51,9 @@ defmodule StellarBase.XDR.SCSpecTypeMap do
   def decode_xdr!(bytes, struct \\ @struct_spec)
 
   def decode_xdr!(bytes, struct) do
-    {%XDR.Struct{components: [keyType: keyType, valueType: valueType]}, rest} =
+    {%XDR.Struct{components: [key_type: key_type, value_type: value_type]}, rest} =
       XDR.Struct.decode_xdr!(bytes, struct)
 
-    {new(keyType, valueType), rest}
+    {new(key_type, value_type), rest}
   end
 end

--- a/lib/xdr/contract/spec/sc_spec_type_option.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_option.ex
@@ -7,28 +7,28 @@ defmodule StellarBase.XDR.SCSpecTypeOption do
 
   @behaviour XDR.Declaration
 
-  @struct_spec XDR.Struct.new(valueType: SCSpecTypeDef)
+  @struct_spec XDR.Struct.new(value_type: SCSpecTypeDef)
 
-  @type valueType :: SCSpecTypeDef.t()
+  @type value_type :: SCSpecTypeDef.t()
 
-  @type t :: %__MODULE__{valueType: valueType()}
+  @type t :: %__MODULE__{value_type: value_type()}
 
-  defstruct [:valueType]
+  defstruct [:value_type]
 
-  @spec new(valueType :: SCSpecTypeDef.t()) :: t()
-  def new(%SCSpecTypeDef{} = valueType),
-    do: %__MODULE__{valueType: valueType}
+  @spec new(value_type :: value_type()) :: t()
+  def new(%SCSpecTypeDef{} = value_type),
+    do: %__MODULE__{value_type: value_type}
 
   @impl true
-  def encode_xdr(%__MODULE__{valueType: valueType}) do
-    [valueType: valueType]
+  def encode_xdr(%__MODULE__{value_type: value_type}) do
+    [value_type: value_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{valueType: valueType}) do
-    [valueType: valueType]
+  def encode_xdr!(%__MODULE__{value_type: value_type}) do
+    [value_type: value_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr!()
   end
@@ -38,8 +38,8 @@ defmodule StellarBase.XDR.SCSpecTypeOption do
 
   def decode_xdr(bytes, struct) do
     case XDR.Struct.decode_xdr(bytes, struct) do
-      {:ok, {%XDR.Struct{components: [valueType: valueType]}, rest}} ->
-        {:ok, {new(valueType), rest}}
+      {:ok, {%XDR.Struct{components: [value_type: value_type]}, rest}} ->
+        {:ok, {new(value_type), rest}}
 
       error ->
         error
@@ -50,9 +50,9 @@ defmodule StellarBase.XDR.SCSpecTypeOption do
   def decode_xdr!(bytes, struct \\ @struct_spec)
 
   def decode_xdr!(bytes, struct) do
-    {%XDR.Struct{components: [valueType: valueType]}, rest} =
+    {%XDR.Struct{components: [value_type: value_type]}, rest} =
       XDR.Struct.decode_xdr!(bytes, struct)
 
-    {new(valueType), rest}
+    {new(value_type), rest}
   end
 end

--- a/lib/xdr/contract/spec/sc_spec_type_option.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_option.ex
@@ -1,0 +1,58 @@
+defmodule StellarBase.XDR.SCSpecTypeOption do
+  @moduledoc """
+  Representation of Stellar `SCSpecTypeOption` type.
+  """
+
+  alias StellarBase.XDR.SCSpecTypeDef
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(valueType: SCSpecTypeDef)
+
+  @type valueType :: SCSpecTypeDef.t()
+
+  @type t :: %__MODULE__{valueType: valueType()}
+
+  defstruct [:valueType]
+
+  @spec new(valueType :: SCSpecTypeDef.t()) :: t()
+  def new(%SCSpecTypeDef{} = valueType),
+    do: %__MODULE__{valueType: valueType}
+
+  @impl true
+  def encode_xdr(%__MODULE__{valueType: valueType}) do
+    [valueType: valueType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{valueType: valueType}) do
+    [valueType: valueType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [valueType: valueType]}, rest}} ->
+        {:ok, {new(valueType), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [valueType: valueType]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(valueType), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_result.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_result.ex
@@ -1,0 +1,59 @@
+defmodule StellarBase.XDR.SCSpecTypeResult do
+  @moduledoc """
+  Representation of Stellar `SCSpecTypeResult` type.
+  """
+
+  alias StellarBase.XDR.SCSpecTypeDef
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(okType: SCSpecTypeDef, errorType: SCSpecTypeDef)
+
+  @type okType :: SCSpecTypeDef.t()
+  @type errorType :: SCSpecTypeDef.t()
+
+  @type t :: %__MODULE__{okType: okType(), errorType: errorType()}
+
+  defstruct [:okType, :errorType]
+
+  @spec new(okType :: SCSpecTypeDef.t(), errorType :: SCSpecTypeDef.t()) :: t()
+  def new(%SCSpecTypeDef{} = okType, %SCSpecTypeDef{} = errorType),
+    do: %__MODULE__{okType: okType, errorType: errorType}
+
+  @impl true
+  def encode_xdr(%__MODULE__{okType: okType, errorType: errorType}) do
+    [okType: okType, errorType: errorType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{okType: okType, errorType: errorType}) do
+    [okType: okType, errorType: errorType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [okType: okType, errorType: errorType]}, rest}} ->
+        {:ok, {new(okType, errorType), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [okType: okType, errorType: errorType]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(okType, errorType), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_result.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_result.ex
@@ -7,29 +7,29 @@ defmodule StellarBase.XDR.SCSpecTypeResult do
 
   @behaviour XDR.Declaration
 
-  @struct_spec XDR.Struct.new(okType: SCSpecTypeDef, errorType: SCSpecTypeDef)
+  @struct_spec XDR.Struct.new(ok_type: SCSpecTypeDef, error_type: SCSpecTypeDef)
 
-  @type okType :: SCSpecTypeDef.t()
-  @type errorType :: SCSpecTypeDef.t()
+  @type ok_type :: SCSpecTypeDef.t()
+  @type error_type :: SCSpecTypeDef.t()
 
-  @type t :: %__MODULE__{okType: okType(), errorType: errorType()}
+  @type t :: %__MODULE__{ok_type: ok_type(), error_type: error_type()}
 
-  defstruct [:okType, :errorType]
+  defstruct [:ok_type, :error_type]
 
-  @spec new(okType :: SCSpecTypeDef.t(), errorType :: SCSpecTypeDef.t()) :: t()
-  def new(%SCSpecTypeDef{} = okType, %SCSpecTypeDef{} = errorType),
-    do: %__MODULE__{okType: okType, errorType: errorType}
+  @spec new(ok_type :: ok_type(), error_type :: error_type()) :: t()
+  def new(%SCSpecTypeDef{} = ok_type, %SCSpecTypeDef{} = error_type),
+    do: %__MODULE__{ok_type: ok_type, error_type: error_type}
 
   @impl true
-  def encode_xdr(%__MODULE__{okType: okType, errorType: errorType}) do
-    [okType: okType, errorType: errorType]
+  def encode_xdr(%__MODULE__{ok_type: ok_type, error_type: error_type}) do
+    [ok_type: ok_type, error_type: error_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{okType: okType, errorType: errorType}) do
-    [okType: okType, errorType: errorType]
+  def encode_xdr!(%__MODULE__{ok_type: ok_type, error_type: error_type}) do
+    [ok_type: ok_type, error_type: error_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr!()
   end
@@ -39,8 +39,8 @@ defmodule StellarBase.XDR.SCSpecTypeResult do
 
   def decode_xdr(bytes, struct) do
     case XDR.Struct.decode_xdr(bytes, struct) do
-      {:ok, {%XDR.Struct{components: [okType: okType, errorType: errorType]}, rest}} ->
-        {:ok, {new(okType, errorType), rest}}
+      {:ok, {%XDR.Struct{components: [ok_type: ok_type, error_type: error_type]}, rest}} ->
+        {:ok, {new(ok_type, error_type), rest}}
 
       error ->
         error
@@ -51,9 +51,9 @@ defmodule StellarBase.XDR.SCSpecTypeResult do
   def decode_xdr!(bytes, struct \\ @struct_spec)
 
   def decode_xdr!(bytes, struct) do
-    {%XDR.Struct{components: [okType: okType, errorType: errorType]}, rest} =
+    {%XDR.Struct{components: [ok_type: ok_type, error_type: error_type]}, rest} =
       XDR.Struct.decode_xdr!(bytes, struct)
 
-    {new(okType, errorType), rest}
+    {new(ok_type, error_type), rest}
   end
 end

--- a/lib/xdr/contract/spec/sc_spec_type_set.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_set.ex
@@ -1,0 +1,58 @@
+defmodule StellarBase.XDR.SCSpecTypeSet do
+  @moduledoc """
+  Representation of Stellar `SCSpecTypeSet` type.
+  """
+
+  alias StellarBase.XDR.SCSpecTypeDef
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(elementType: SCSpecTypeDef)
+
+  @type elementType :: SCSpecTypeDef.t()
+
+  @type t :: %__MODULE__{elementType: elementType()}
+
+  defstruct [:elementType]
+
+  @spec new(elementType :: SCSpecTypeDef.t()) :: t()
+  def new(%SCSpecTypeDef{} = elementType),
+    do: %__MODULE__{elementType: elementType}
+
+  @impl true
+  def encode_xdr(%__MODULE__{elementType: elementType}) do
+    [elementType: elementType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{elementType: elementType}) do
+    [elementType: elementType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [elementType: elementType]}, rest}} ->
+        {:ok, {new(elementType), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [elementType: elementType]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(elementType), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_set.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_set.ex
@@ -7,28 +7,28 @@ defmodule StellarBase.XDR.SCSpecTypeSet do
 
   @behaviour XDR.Declaration
 
-  @struct_spec XDR.Struct.new(elementType: SCSpecTypeDef)
+  @struct_spec XDR.Struct.new(element_type: SCSpecTypeDef)
 
-  @type elementType :: SCSpecTypeDef.t()
+  @type element_type :: SCSpecTypeDef.t()
 
-  @type t :: %__MODULE__{elementType: elementType()}
+  @type t :: %__MODULE__{element_type: element_type()}
 
-  defstruct [:elementType]
+  defstruct [:element_type]
 
-  @spec new(elementType :: SCSpecTypeDef.t()) :: t()
-  def new(%SCSpecTypeDef{} = elementType),
-    do: %__MODULE__{elementType: elementType}
+  @spec new(element_type :: element_type()) :: t()
+  def new(%SCSpecTypeDef{} = element_type),
+    do: %__MODULE__{element_type: element_type}
 
   @impl true
-  def encode_xdr(%__MODULE__{elementType: elementType}) do
-    [elementType: elementType]
+  def encode_xdr(%__MODULE__{element_type: element_type}) do
+    [element_type: element_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{elementType: elementType}) do
-    [elementType: elementType]
+  def encode_xdr!(%__MODULE__{element_type: element_type}) do
+    [element_type: element_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr!()
   end
@@ -38,8 +38,8 @@ defmodule StellarBase.XDR.SCSpecTypeSet do
 
   def decode_xdr(bytes, struct) do
     case XDR.Struct.decode_xdr(bytes, struct) do
-      {:ok, {%XDR.Struct{components: [elementType: elementType]}, rest}} ->
-        {:ok, {new(elementType), rest}}
+      {:ok, {%XDR.Struct{components: [element_type: element_type]}, rest}} ->
+        {:ok, {new(element_type), rest}}
 
       error ->
         error
@@ -50,9 +50,9 @@ defmodule StellarBase.XDR.SCSpecTypeSet do
   def decode_xdr!(bytes, struct \\ @struct_spec)
 
   def decode_xdr!(bytes, struct) do
-    {%XDR.Struct{components: [elementType: elementType]}, rest} =
+    {%XDR.Struct{components: [element_type: element_type]}, rest} =
       XDR.Struct.decode_xdr!(bytes, struct)
 
-    {new(elementType), rest}
+    {new(element_type), rest}
   end
 end

--- a/lib/xdr/contract/spec/sc_spec_type_tuple.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_tuple.ex
@@ -7,28 +7,28 @@ defmodule StellarBase.XDR.SCSpecTypeTuple do
 
   @behaviour XDR.Declaration
 
-  @struct_spec XDR.Struct.new(valueTypes: SCSpecTypeDef12)
+  @struct_spec XDR.Struct.new(value_types: SCSpecTypeDef12)
 
-  @type valueTypes :: SCSpecTypeDef12.t()
+  @type value_types :: SCSpecTypeDef12.t()
 
-  @type t :: %__MODULE__{valueTypes: valueTypes()}
+  @type t :: %__MODULE__{value_types: value_types()}
 
-  defstruct [:valueTypes]
+  defstruct [:value_types]
 
-  @spec new(valueTypes :: SCSpecTypeDef12.t()) :: t()
-  def new(%SCSpecTypeDef12{} = valueTypes),
-    do: %__MODULE__{valueTypes: valueTypes}
+  @spec new(value_types :: value_types()) :: t()
+  def new(%SCSpecTypeDef12{} = value_types),
+    do: %__MODULE__{value_types: value_types}
 
   @impl true
-  def encode_xdr(%__MODULE__{valueTypes: valueTypes}) do
-    [valueTypes: valueTypes]
+  def encode_xdr(%__MODULE__{value_types: value_types}) do
+    [value_types: value_types]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{valueTypes: valueTypes}) do
-    [valueTypes: valueTypes]
+  def encode_xdr!(%__MODULE__{value_types: value_types}) do
+    [value_types: value_types]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr!()
   end
@@ -38,8 +38,8 @@ defmodule StellarBase.XDR.SCSpecTypeTuple do
 
   def decode_xdr(bytes, struct) do
     case XDR.Struct.decode_xdr(bytes, struct) do
-      {:ok, {%XDR.Struct{components: [valueTypes: valueTypes]}, rest}} ->
-        {:ok, {new(valueTypes), rest}}
+      {:ok, {%XDR.Struct{components: [value_types: value_types]}, rest}} ->
+        {:ok, {new(value_types), rest}}
 
       error ->
         error
@@ -50,9 +50,9 @@ defmodule StellarBase.XDR.SCSpecTypeTuple do
   def decode_xdr!(bytes, struct \\ @struct_spec)
 
   def decode_xdr!(bytes, struct) do
-    {%XDR.Struct{components: [valueTypes: valueTypes]}, rest} =
+    {%XDR.Struct{components: [value_types: value_types]}, rest} =
       XDR.Struct.decode_xdr!(bytes, struct)
 
-    {new(valueTypes), rest}
+    {new(value_types), rest}
   end
 end

--- a/lib/xdr/contract/spec/sc_spec_type_tuple.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_tuple.ex
@@ -1,0 +1,58 @@
+defmodule StellarBase.XDR.SCSpecTypeTuple do
+  @moduledoc """
+  Representation of Stellar `SCSpecTypeTuple` type.
+  """
+
+  alias StellarBase.XDR.SCSpecTypeDef12
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(valueTypes: SCSpecTypeDef12)
+
+  @type valueTypes :: SCSpecTypeDef12.t()
+
+  @type t :: %__MODULE__{valueTypes: valueTypes()}
+
+  defstruct [:valueTypes]
+
+  @spec new(valueTypes :: SCSpecTypeDef12.t()) :: t()
+  def new(%SCSpecTypeDef12{} = valueTypes),
+    do: %__MODULE__{valueTypes: valueTypes}
+
+  @impl true
+  def encode_xdr(%__MODULE__{valueTypes: valueTypes}) do
+    [valueTypes: valueTypes]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{valueTypes: valueTypes}) do
+    [valueTypes: valueTypes]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [valueTypes: valueTypes]}, rest}} ->
+        {:ok, {new(valueTypes), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [valueTypes: valueTypes]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(valueTypes), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_vec.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_vec.ex
@@ -1,0 +1,58 @@
+defmodule StellarBase.XDR.SCSpecTypeVec do
+  @moduledoc """
+  Representation of Stellar `SCSpecTypeVec` type.
+  """
+
+  alias StellarBase.XDR.SCSpecTypeDef
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(elementType: SCSpecTypeDef)
+
+  @type elementType :: SCSpecTypeDef.t()
+
+  @type t :: %__MODULE__{elementType: elementType()}
+
+  defstruct [:elementType]
+
+  @spec new(elementType :: SCSpecTypeDef.t()) :: t()
+  def new(%SCSpecTypeDef{} = elementType),
+    do: %__MODULE__{elementType: elementType}
+
+  @impl true
+  def encode_xdr(%__MODULE__{elementType: elementType}) do
+    [elementType: elementType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{elementType: elementType}) do
+    [elementType: elementType]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [elementType: elementType]}, rest}} ->
+        {:ok, {new(elementType), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [elementType: elementType]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(elementType), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_type_vec.ex
+++ b/lib/xdr/contract/spec/sc_spec_type_vec.ex
@@ -7,28 +7,28 @@ defmodule StellarBase.XDR.SCSpecTypeVec do
 
   @behaviour XDR.Declaration
 
-  @struct_spec XDR.Struct.new(elementType: SCSpecTypeDef)
+  @struct_spec XDR.Struct.new(element_type: SCSpecTypeDef)
 
-  @type elementType :: SCSpecTypeDef.t()
+  @type element_type :: SCSpecTypeDef.t()
 
-  @type t :: %__MODULE__{elementType: elementType()}
+  @type t :: %__MODULE__{element_type: element_type()}
 
-  defstruct [:elementType]
+  defstruct [:element_type]
 
-  @spec new(elementType :: SCSpecTypeDef.t()) :: t()
-  def new(%SCSpecTypeDef{} = elementType),
-    do: %__MODULE__{elementType: elementType}
+  @spec new(element_type :: element_type()) :: t()
+  def new(%SCSpecTypeDef{} = element_type),
+    do: %__MODULE__{element_type: element_type}
 
   @impl true
-  def encode_xdr(%__MODULE__{elementType: elementType}) do
-    [elementType: elementType]
+  def encode_xdr(%__MODULE__{element_type: element_type}) do
+    [element_type: element_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr()
   end
 
   @impl true
-  def encode_xdr!(%__MODULE__{elementType: elementType}) do
-    [elementType: elementType]
+  def encode_xdr!(%__MODULE__{element_type: element_type}) do
+    [element_type: element_type]
     |> XDR.Struct.new()
     |> XDR.Struct.encode_xdr!()
   end
@@ -38,8 +38,8 @@ defmodule StellarBase.XDR.SCSpecTypeVec do
 
   def decode_xdr(bytes, struct) do
     case XDR.Struct.decode_xdr(bytes, struct) do
-      {:ok, {%XDR.Struct{components: [elementType: elementType]}, rest}} ->
-        {:ok, {new(elementType), rest}}
+      {:ok, {%XDR.Struct{components: [element_type: element_type]}, rest}} ->
+        {:ok, {new(element_type), rest}}
 
       error ->
         error
@@ -50,9 +50,9 @@ defmodule StellarBase.XDR.SCSpecTypeVec do
   def decode_xdr!(bytes, struct \\ @struct_spec)
 
   def decode_xdr!(bytes, struct) do
-    {%XDR.Struct{components: [elementType: elementType]}, rest} =
+    {%XDR.Struct{components: [element_type: element_type]}, rest} =
       XDR.Struct.decode_xdr!(bytes, struct)
 
-    {new(elementType), rest}
+    {new(element_type), rest}
   end
 end

--- a/lib/xdr/contract/spec/sc_spec_udt_union_case_tuple_v0.ex
+++ b/lib/xdr/contract/spec/sc_spec_udt_union_case_tuple_v0.ex
@@ -1,0 +1,60 @@
+defmodule StellarBase.XDR.SCSpecUDTUnionCaseTupleV0 do
+  @moduledoc """
+  Representation of Stellar `SCSpecUDTUnionCaseTupleV0` type.
+  """
+
+  alias StellarBase.XDR.{SCSpecTypeDef12, String60, String1024}
+
+  @behaviour XDR.Declaration
+
+  @struct_spec XDR.Struct.new(doc: String1024, name: String60, type: SCSpecTypeDef12)
+
+  @type doc :: String1024.t()
+  @type name :: String60.t()
+  @type type :: SCSpecTypeDef12.t()
+
+  @type t :: %__MODULE__{doc: doc(), name: name(), type: type()}
+
+  defstruct [:doc, :name, :type]
+
+  @spec new(doc :: String1024.t(), name :: String60.t(), type :: SCSpecTypeDef12.t()) :: t()
+  def new(%String1024{} = doc, %String60{} = name, %SCSpecTypeDef12{} = type),
+    do: %__MODULE__{doc: doc, name: name, type: type}
+
+  @impl true
+  def encode_xdr(%__MODULE__{doc: doc, name: name, type: type}) do
+    [doc: doc, name: name, type: type]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr()
+  end
+
+  @impl true
+  def encode_xdr!(%__MODULE__{doc: doc, name: name, type: type}) do
+    [doc: doc, name: name, type: type]
+    |> XDR.Struct.new()
+    |> XDR.Struct.encode_xdr!()
+  end
+
+  @impl true
+  def decode_xdr(bytes, struct \\ @struct_spec)
+
+  def decode_xdr(bytes, struct) do
+    case XDR.Struct.decode_xdr(bytes, struct) do
+      {:ok, {%XDR.Struct{components: [doc: doc, name: name, type: type]}, rest}} ->
+        {:ok, {new(doc, name, type), rest}}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def decode_xdr!(bytes, struct \\ @struct_spec)
+
+  def decode_xdr!(bytes, struct) do
+    {%XDR.Struct{components: [doc: doc, name: name, type: type]}, rest} =
+      XDR.Struct.decode_xdr!(bytes, struct)
+
+    {new(doc, name, type), rest}
+  end
+end

--- a/lib/xdr/contract/spec/sc_spec_udt_union_case_tuple_v0.ex
+++ b/lib/xdr/contract/spec/sc_spec_udt_union_case_tuple_v0.ex
@@ -17,7 +17,7 @@ defmodule StellarBase.XDR.SCSpecUDTUnionCaseTupleV0 do
 
   defstruct [:doc, :name, :type]
 
-  @spec new(doc :: String1024.t(), name :: String60.t(), type :: SCSpecTypeDef12.t()) :: t()
+  @spec new(doc :: doc(), name :: name(), type :: type()) :: t()
   def new(%String1024{} = doc, %String60{} = name, %SCSpecTypeDef12{} = type),
     do: %__MODULE__{doc: doc, name: name, type: type}
 

--- a/test/xdr/contract/spec/sc_spec_function_input_v0_list_test.exs
+++ b/test/xdr/contract/spec/sc_spec_function_input_v0_list_test.exs
@@ -13,32 +13,38 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0ListTest do
 
   describe "SCSpecFunctionInputV0List" do
     setup do
-      sc_spec_function_input_v01 =
+      doc = String1024.new("Hello there this is a test")
+      name = String30.new("Hello there")
+      code = Void.new()
+      type = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      sc_spec_type_def = SCSpecTypeDef.new(code, type)
+
+      sc_spec_function_input_v0_1 =
         SCSpecFunctionInputV0.new(
-          String1024.new("Hello there this is a test"),
-          String30.new("Hello there"),
-          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+          doc,
+          name,
+          sc_spec_type_def
         )
 
-      sc_spec_function_input_v02 =
+      sc_spec_function_input_v0_2 =
         SCSpecFunctionInputV0.new(
-          String1024.new("Hello there this is a test 1"),
-          String30.new("Hello there 1"),
-          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+          doc,
+          name,
+          sc_spec_type_def
         )
 
-      inputs = [sc_spec_function_input_v01, sc_spec_function_input_v02]
+      inputs = [sc_spec_function_input_v0_1, sc_spec_function_input_v0_2]
 
       %{
         inputs: inputs,
-        sponsorship_descriptor_list: inputs |> SCSpecFunctionInputV0List.new(),
+        sponsorship_descriptor_list: SCSpecFunctionInputV0List.new(inputs),
         binary:
           <<0, 0, 0, 2, 0, 0, 0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116,
             104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 11, 72,
-            101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 0, 0, 0, 0, 0, 0, 0, 0, 28, 72, 101,
+            101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 0, 0, 0, 0, 0, 0, 0, 0, 26, 72, 101,
             108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116, 104, 105, 115, 32, 105, 115, 32,
-            97, 32, 116, 101, 115, 116, 32, 49, 0, 0, 0, 13, 72, 101, 108, 108, 111, 32, 116, 104,
-            101, 114, 101, 32, 49, 0, 0, 0, 0, 0, 0, 0>>
+            97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 11, 72, 101, 108, 108, 111, 32, 116, 104,
+            101, 114, 101, 0, 0, 0, 0, 0>>
       }
     end
 

--- a/test/xdr/contract/spec/sc_spec_function_input_v0_list_test.exs
+++ b/test/xdr/contract/spec/sc_spec_function_input_v0_list_test.exs
@@ -1,0 +1,89 @@
+defmodule StellarBase.XDR.SCSpecFunctionInputV0ListTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    Void,
+    SCSpecTypeDef,
+    String30,
+    String1024,
+    SCSpecType,
+    SCSpecFunctionInputV0,
+    SCSpecFunctionInputV0List
+  }
+
+  describe "SCSpecFunctionInputV0List" do
+    setup do
+      sc_spec_function_input_v01 =
+        SCSpecFunctionInputV0.new(
+          String1024.new("Hello there this is a test"),
+          String30.new("Hello there"),
+          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+        )
+
+      sc_spec_function_input_v02 =
+        SCSpecFunctionInputV0.new(
+          String1024.new("Hello there this is a test 1"),
+          String30.new("Hello there 1"),
+          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+        )
+
+      sc_spec_function_input_v0_list = [sc_spec_function_input_v01, sc_spec_function_input_v02]
+
+      %{
+        sc_spec_function_input_v0_list: sc_spec_function_input_v0_list,
+        sponsorship_descriptor_list:
+          SCSpecFunctionInputV0List.new([sc_spec_function_input_v01, sc_spec_function_input_v02]),
+        binary:
+          <<0, 0, 0, 2, 0, 0, 0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116,
+            104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 11, 72,
+            101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 0, 0, 0, 0, 0, 0, 0, 0, 28, 72, 101,
+            108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116, 104, 105, 115, 32, 105, 115, 32,
+            97, 32, 116, 101, 115, 116, 32, 49, 0, 0, 0, 13, 72, 101, 108, 108, 111, 32, 116, 104,
+            101, 114, 101, 32, 49, 0, 0, 0, 0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{sc_spec_function_input_v0_list: sc_spec_function_input_v0_list} do
+      %SCSpecFunctionInputV0List{sc_spec_function_input_v0_list: ^sc_spec_function_input_v0_list} =
+        SCSpecFunctionInputV0List.new(sc_spec_function_input_v0_list)
+    end
+
+    test "encode_xdr/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {:ok, ^binary} = SCSpecFunctionInputV0List.encode_xdr(sponsorship_descriptor_list)
+    end
+
+    test "encode_xdr!/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      ^binary = SCSpecFunctionInputV0List.encode_xdr!(sponsorship_descriptor_list)
+    end
+
+    test "decode_xdr/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {:ok, {^sponsorship_descriptor_list, ""}} = SCSpecFunctionInputV0List.decode_xdr(binary)
+    end
+
+    test "decode_xdr/1 with an invalid binary" do
+      {:error, :not_binary} = SCSpecFunctionInputV0List.decode_xdr(123)
+    end
+
+    test "decode_xdr!/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {^sponsorship_descriptor_list, ""} = SCSpecFunctionInputV0List.decode_xdr!(binary)
+    end
+
+    test "decode_xdr!/1 with an invalid binary" do
+      assert_raise XDR.VariableArrayError,
+                   "The value which you pass through parameters must be a binary value, for example: <<0, 0, 0, 5>>",
+                   fn -> SCSpecFunctionInputV0List.decode_xdr!(123) end
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_function_input_v0_list_test.exs
+++ b/test/xdr/contract/spec/sc_spec_function_input_v0_list_test.exs
@@ -27,10 +27,10 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0ListTest do
           SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
         )
 
-      sc_spec_function_input_v0_list = [sc_spec_function_input_v01, sc_spec_function_input_v02]
+      input_list = [sc_spec_function_input_v01, sc_spec_function_input_v02]
 
       %{
-        sc_spec_function_input_v0_list: sc_spec_function_input_v0_list,
+        input_list: input_list,
         sponsorship_descriptor_list:
           SCSpecFunctionInputV0List.new([sc_spec_function_input_v01, sc_spec_function_input_v02]),
         binary:
@@ -43,9 +43,9 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0ListTest do
       }
     end
 
-    test "new/1", %{sc_spec_function_input_v0_list: sc_spec_function_input_v0_list} do
-      %SCSpecFunctionInputV0List{sc_spec_function_input_v0_list: ^sc_spec_function_input_v0_list} =
-        SCSpecFunctionInputV0List.new(sc_spec_function_input_v0_list)
+    test "new/1", %{input_list: input_list} do
+      %SCSpecFunctionInputV0List{input_list: ^input_list} =
+        SCSpecFunctionInputV0List.new(input_list)
     end
 
     test "encode_xdr/1", %{

--- a/test/xdr/contract/spec/sc_spec_function_input_v0_list_test.exs
+++ b/test/xdr/contract/spec/sc_spec_function_input_v0_list_test.exs
@@ -27,12 +27,11 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0ListTest do
           SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
         )
 
-      input_list = [sc_spec_function_input_v01, sc_spec_function_input_v02]
+      inputs = [sc_spec_function_input_v01, sc_spec_function_input_v02]
 
       %{
-        input_list: input_list,
-        sponsorship_descriptor_list:
-          SCSpecFunctionInputV0List.new([sc_spec_function_input_v01, sc_spec_function_input_v02]),
+        inputs: inputs,
+        sponsorship_descriptor_list: inputs |> SCSpecFunctionInputV0List.new(),
         binary:
           <<0, 0, 0, 2, 0, 0, 0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116,
             104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 11, 72,
@@ -43,9 +42,8 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0ListTest do
       }
     end
 
-    test "new/1", %{input_list: input_list} do
-      %SCSpecFunctionInputV0List{input_list: ^input_list} =
-        SCSpecFunctionInputV0List.new(input_list)
+    test "new/1", %{inputs: inputs} do
+      %SCSpecFunctionInputV0List{inputs: ^inputs} = SCSpecFunctionInputV0List.new(inputs)
     end
 
     test "encode_xdr/1", %{

--- a/test/xdr/contract/spec/sc_spec_function_input_v0_test.exs
+++ b/test/xdr/contract/spec/sc_spec_function_input_v0_test.exs
@@ -14,7 +14,9 @@ defmodule StellarBase.XDR.SCSpecFunctionInputV0Test do
     setup do
       doc = String1024.new("Hello there this is a test")
       name = String30.new("Hello there")
-      type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      code = Void.new()
+      type_val = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      type = SCSpecTypeDef.new(code, type_val)
 
       %{
         doc: doc,

--- a/test/xdr/contract/spec/sc_spec_function_input_v0_test.exs
+++ b/test/xdr/contract/spec/sc_spec_function_input_v0_test.exs
@@ -1,0 +1,68 @@
+defmodule StellarBase.XDR.SCSpecFunctionInputV0Test do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    String1024,
+    String30,
+    SCSpecFunctionInputV0,
+    SCSpecTypeDef,
+    SCSpecType,
+    Void
+  }
+
+  describe "SCSpecFunctionInputV0" do
+    setup do
+      doc = String1024.new("Hello there this is a test")
+      name = String30.new("Hello there")
+      type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+
+      %{
+        doc: doc,
+        name: name,
+        type: type,
+        sc_spec_function_input_v0: SCSpecFunctionInputV0.new(doc, name, type),
+        binary:
+          <<0, 0, 0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116, 104, 105,
+            115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 11, 72, 101, 108,
+            108, 111, 32, 116, 104, 101, 114, 101, 0, 0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{doc: doc, name: name, type: type} do
+      %SCSpecFunctionInputV0{doc: ^doc, name: ^name, type: ^type} =
+        SCSpecFunctionInputV0.new(doc, name, type)
+    end
+
+    test "encode_xdr/1", %{
+      sc_spec_function_input_v0: sc_spec_function_input_v0,
+      binary: binary
+    } do
+      {:ok, ^binary} = SCSpecFunctionInputV0.encode_xdr(sc_spec_function_input_v0)
+    end
+
+    test "encode_xdr!/1", %{
+      sc_spec_function_input_v0: sc_spec_function_input_v0,
+      binary: binary
+    } do
+      ^binary = SCSpecFunctionInputV0.encode_xdr!(sc_spec_function_input_v0)
+    end
+
+    test "decode_xdr/2", %{
+      sc_spec_function_input_v0: sc_spec_function_input_v0,
+      binary: binary
+    } do
+      {:ok, {^sc_spec_function_input_v0, ""}} = SCSpecFunctionInputV0.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecFunctionInputV0.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{
+      sc_spec_function_input_v0: sc_spec_function_input_v0,
+      binary: binary
+    } do
+      {^sc_spec_function_input_v0, ^binary} = SCSpecFunctionInputV0.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_function_v0_test.exs
+++ b/test/xdr/contract/spec/sc_spec_function_v0_test.exs
@@ -18,24 +18,34 @@ defmodule StellarBase.XDR.SCSpecFunctionV0Test do
     setup do
       doc = String1024.new("Hello there this is a test")
       name = SCSymbol.new("name10")
+      code = Void.new()
+      function_input_v0_name = String30.new("string30")
+      type_val = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      type = SCSpecTypeDef.new(code, type_val)
+
+      sc_spec_function_input_v0_1 =
+        SCSpecFunctionInputV0.new(
+          doc,
+          function_input_v0_name,
+          type
+        )
+
+      sc_spec_function_input_v0_2 =
+        SCSpecFunctionInputV0.new(
+          doc,
+          function_input_v0_name,
+          type
+        )
 
       inputs =
         SCSpecFunctionInputV0List.new([
-          SCSpecFunctionInputV0.new(
-            String1024.new("Hello there this is a test"),
-            String30.new("Hello there"),
-            SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
-          ),
-          SCSpecFunctionInputV0.new(
-            String1024.new("Hello there this is test 2"),
-            String30.new("Hello there 2"),
-            SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
-          )
+          sc_spec_function_input_v0_1,
+          sc_spec_function_input_v0_2
         ])
 
       outputs =
         SCSpecTypeDef1.new([
-          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+          type
         ])
 
       %{
@@ -49,11 +59,10 @@ defmodule StellarBase.XDR.SCSpecFunctionV0Test do
             115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 6, 110, 97, 109,
             101, 49, 48, 0, 0, 0, 0, 0, 2, 0, 0, 0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101,
             114, 101, 32, 116, 104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0,
-            0, 0, 0, 11, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 0, 0, 0, 0, 0, 0, 0,
-            0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116, 104, 105, 115,
-            32, 105, 115, 32, 116, 101, 115, 116, 32, 50, 0, 0, 0, 0, 0, 13, 72, 101, 108, 108,
-            111, 32, 116, 104, 101, 114, 101, 32, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
-            0>>
+            0, 0, 0, 8, 115, 116, 114, 105, 110, 103, 51, 48, 0, 0, 0, 0, 0, 0, 0, 26, 72, 101,
+            108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116, 104, 105, 115, 32, 105, 115, 32,
+            97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 8, 115, 116, 114, 105, 110, 103, 51, 48, 0,
+            0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0>>
       }
     end
 

--- a/test/xdr/contract/spec/sc_spec_function_v0_test.exs
+++ b/test/xdr/contract/spec/sc_spec_function_v0_test.exs
@@ -1,0 +1,97 @@
+defmodule StellarBase.XDR.SCSpecFunctionV0Test do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    SCSpecTypeDef1,
+    String1024,
+    SCSymbol,
+    SCSpecFunctionInputV0List,
+    SCSpecFunctionInputV0,
+    SCSpecTypeDef,
+    SCSpecFunctionV0,
+    Void,
+    SCSpecType,
+    String30
+  }
+
+  describe "SCSpecFunctionV0" do
+    setup do
+      doc = String1024.new("Hello there this is a test")
+      name = SCSymbol.new("name10")
+
+      inputs =
+        SCSpecFunctionInputV0List.new([
+          SCSpecFunctionInputV0.new(
+            String1024.new("Hello there this is a test"),
+            String30.new("Hello there"),
+            SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+          ),
+          SCSpecFunctionInputV0.new(
+            String1024.new("Hello there this is test 2"),
+            String30.new("Hello there 2"),
+            SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+          )
+        ])
+
+      outputs =
+        SCSpecTypeDef1.new([
+          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+        ])
+
+      %{
+        doc: doc,
+        name: name,
+        inputs: inputs,
+        outputs: outputs,
+        sc_spec_function_v0: SCSpecFunctionV0.new(doc, name, inputs, outputs),
+        binary:
+          <<0, 0, 0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116, 104, 105,
+            115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 6, 110, 97, 109,
+            101, 49, 48, 0, 0, 0, 0, 0, 2, 0, 0, 0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101,
+            114, 101, 32, 116, 104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0,
+            0, 0, 0, 11, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 0, 0, 0, 0, 0, 0, 0,
+            0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116, 104, 105, 115,
+            32, 105, 115, 32, 116, 101, 115, 116, 32, 50, 0, 0, 0, 0, 0, 13, 72, 101, 108, 108,
+            111, 32, 116, 104, 101, 114, 101, 32, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+            0>>
+      }
+    end
+
+    test "new/1", %{doc: doc, name: name, inputs: inputs, outputs: outputs} do
+      %SCSpecFunctionV0{doc: ^doc, name: ^name, inputs: ^inputs, outputs: ^outputs} =
+        SCSpecFunctionV0.new(doc, name, inputs, outputs)
+    end
+
+    test "encode_xdr/1", %{
+      sc_spec_function_v0: sc_spec_function_v0,
+      binary: binary
+    } do
+      {:ok, ^binary} = SCSpecFunctionV0.encode_xdr(sc_spec_function_v0)
+    end
+
+    test "encode_xdr!/1", %{
+      sc_spec_function_v0: sc_spec_function_v0,
+      binary: binary
+    } do
+      ^binary = SCSpecFunctionV0.encode_xdr!(sc_spec_function_v0)
+    end
+
+    test "decode_xdr/2", %{
+      sc_spec_function_v0: sc_spec_function_v0,
+      binary: binary
+    } do
+      {:ok, {^sc_spec_function_v0, ""}} = SCSpecFunctionV0.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecFunctionV0.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{
+      sc_spec_function_v0: sc_spec_function_v0,
+      binary: binary
+    } do
+      {^sc_spec_function_v0, ^binary} = SCSpecFunctionV0.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_def12_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_def12_test.exs
@@ -1,0 +1,63 @@
+defmodule StellarBase.XDR.SCSpecTypeDef12Test do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{Void, SCSpecTypeDef, SCSpecTypeDef12, SCSpecType}
+
+  describe "SCSpecTypeDef12" do
+    setup do
+      sc_spec_type_def1 = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      sc_spec_type_def2 = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+
+      sc_spec_type_defs = [sc_spec_type_def1, sc_spec_type_def2]
+
+      %{
+        sc_spec_type_defs: sc_spec_type_defs,
+        sponsorship_descriptor_list: SCSpecTypeDef12.new([sc_spec_type_def1, sc_spec_type_def2]),
+        binary: <<0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5>>
+      }
+    end
+
+    test "new/1", %{sc_spec_type_defs: sc_spec_type_defs} do
+      %SCSpecTypeDef12{sc_spec_type_defs: ^sc_spec_type_defs} =
+        SCSpecTypeDef12.new(sc_spec_type_defs)
+    end
+
+    test "encode_xdr/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {:ok, ^binary} = SCSpecTypeDef12.encode_xdr(sponsorship_descriptor_list)
+    end
+
+    test "encode_xdr!/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      ^binary = SCSpecTypeDef12.encode_xdr!(sponsorship_descriptor_list)
+    end
+
+    test "decode_xdr/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {:ok, {^sponsorship_descriptor_list, ""}} = SCSpecTypeDef12.decode_xdr(binary)
+    end
+
+    test "decode_xdr/1 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeDef12.decode_xdr(123)
+    end
+
+    test "decode_xdr!/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {^sponsorship_descriptor_list, ""} = SCSpecTypeDef12.decode_xdr!(binary)
+    end
+
+    test "decode_xdr!/1 with an invalid binary" do
+      assert_raise XDR.VariableArrayError,
+                   "The value which you pass through parameters must be a binary value, for example: <<0, 0, 0, 5>>",
+                   fn -> SCSpecTypeDef12.decode_xdr!(123) end
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_def12_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_def12_test.exs
@@ -5,8 +5,11 @@ defmodule StellarBase.XDR.SCSpecTypeDef12Test do
 
   describe "SCSpecTypeDef12" do
     setup do
-      sc_spec_type_def1 = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
-      sc_spec_type_def2 = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+      code = Void.new()
+      type_val = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      type_u128 = SCSpecType.new(:SC_SPEC_TYPE_U128)
+      sc_spec_type_def1 = SCSpecTypeDef.new(code, type_val)
+      sc_spec_type_def2 = SCSpecTypeDef.new(code, type_u128)
 
       sc_spec_type_defs = [sc_spec_type_def1, sc_spec_type_def2]
 

--- a/test/xdr/contract/spec/sc_spec_type_def1_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_def1_test.exs
@@ -1,0 +1,62 @@
+defmodule StellarBase.XDR.SCSpecTypeDef1Test do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{Void, SCSpecTypeDef, SCSpecTypeDef1, SCSpecType}
+
+  describe "SCSpecTypeDef1" do
+    setup do
+      sc_spec_type_def1 = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+
+      sc_spec_type_defs = [sc_spec_type_def1]
+
+      %{
+        sc_spec_type_defs: sc_spec_type_defs,
+        sponsorship_descriptor_list: SCSpecTypeDef1.new([sc_spec_type_def1]),
+        binary: <<0, 0, 0, 1, 0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{sc_spec_type_defs: sc_spec_type_defs} do
+      %SCSpecTypeDef1{sc_spec_type_defs: ^sc_spec_type_defs} =
+        SCSpecTypeDef1.new(sc_spec_type_defs)
+    end
+
+    test "encode_xdr/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {:ok, ^binary} = SCSpecTypeDef1.encode_xdr(sponsorship_descriptor_list)
+    end
+
+    test "encode_xdr!/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      ^binary = SCSpecTypeDef1.encode_xdr!(sponsorship_descriptor_list)
+    end
+
+    test "decode_xdr/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {:ok, {^sponsorship_descriptor_list, ""}} = SCSpecTypeDef1.decode_xdr(binary)
+    end
+
+    test "decode_xdr/1 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeDef1.decode_xdr(123)
+    end
+
+    test "decode_xdr!/1", %{
+      sponsorship_descriptor_list: sponsorship_descriptor_list,
+      binary: binary
+    } do
+      {^sponsorship_descriptor_list, ""} = SCSpecTypeDef1.decode_xdr!(binary)
+    end
+
+    test "decode_xdr!/1 with an invalid binary" do
+      assert_raise XDR.VariableArrayError,
+                   "The value which you pass through parameters must be a binary value, for example: <<0, 0, 0, 5>>",
+                   fn -> SCSpecTypeDef1.decode_xdr!(123) end
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_def1_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_def1_test.exs
@@ -5,7 +5,9 @@ defmodule StellarBase.XDR.SCSpecTypeDef1Test do
 
   describe "SCSpecTypeDef1" do
     setup do
-      sc_spec_type_def1 = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      code = Void.new()
+      type = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      sc_spec_type_def1 = SCSpecTypeDef.new(code, type)
 
       sc_spec_type_defs = [sc_spec_type_def1]
 

--- a/test/xdr/contract/spec/sc_spec_type_def_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_def_test.exs
@@ -20,6 +20,12 @@ defmodule StellarBase.XDR.SCSpecTypeDefTest do
 
   describe "SCSpecTypeDef" do
     setup do
+      code = Void.new()
+      type_val = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      type_u128 = SCSpecType.new(:SC_SPEC_TYPE_U128)
+      sc_spec_type_def_1 = SCSpecTypeDef.new(code, type_val)
+      sc_spec_type_def_2 = SCSpecTypeDef.new(code, type_u128)
+
       discriminants = [
         %{
           status_type: SCSpecType.new(:SC_SPEC_TYPE_VAL),
@@ -88,7 +94,7 @@ defmodule StellarBase.XDR.SCSpecTypeDefTest do
         },
         %{
           sc_code:
-            SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+            sc_spec_type_def_1
             |> SCSpecTypeOption.new(),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_OPTION),
           binary: <<0, 0, 3, 232, 0, 0, 0, 0>>
@@ -96,43 +102,38 @@ defmodule StellarBase.XDR.SCSpecTypeDefTest do
         %{
           sc_code:
             SCSpecTypeResult.new(
-              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
-              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+              sc_spec_type_def_1,
+              sc_spec_type_def_2
             ),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_RESULT),
           binary: <<0, 0, 3, 233, 0, 0, 0, 0, 0, 0, 0, 5>>
         },
         %{
           sc_code:
-            SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+            sc_spec_type_def_1
             |> SCSpecTypeVec.new(),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_VEC),
           binary: <<0, 0, 3, 234, 0, 0, 0, 0>>
         },
         %{
           sc_code:
-            SCSpecTypeDef.new(
-              Void.new(),
-              SCSpecType.new(:SC_SPEC_TYPE_VAL)
-            )
+            sc_spec_type_def_1
             |> SCSpecTypeSet.new(),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_SET),
           binary: <<0, 0, 3, 235, 0, 0, 0, 0>>
         },
         %{
           sc_code:
-            SCSpecTypeMap.new(
-              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
-              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
-            ),
+            sc_spec_type_def_1
+            |> SCSpecTypeMap.new(sc_spec_type_def_2),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_MAP),
           binary: <<0, 0, 3, 236, 0, 0, 0, 0, 0, 0, 0, 5>>
         },
         %{
           sc_code:
             SCSpecTypeDef12.new([
-              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
-              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+              sc_spec_type_def_1,
+              sc_spec_type_def_2
             ])
             |> SCSpecTypeTuple.new(),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_TUPLE),

--- a/test/xdr/contract/spec/sc_spec_type_def_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_def_test.exs
@@ -88,7 +88,8 @@ defmodule StellarBase.XDR.SCSpecTypeDefTest do
         },
         %{
           sc_code:
-            SCSpecTypeOption.new(SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))),
+            SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+            |> SCSpecTypeOption.new(),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_OPTION),
           binary: <<0, 0, 3, 232, 0, 0, 0, 0>>
         },
@@ -103,13 +104,18 @@ defmodule StellarBase.XDR.SCSpecTypeDefTest do
         },
         %{
           sc_code:
-            SCSpecTypeVec.new(SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))),
+            SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+            |> SCSpecTypeVec.new(),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_VEC),
           binary: <<0, 0, 3, 234, 0, 0, 0, 0>>
         },
         %{
           sc_code:
-            SCSpecTypeSet.new(SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))),
+            SCSpecTypeDef.new(
+              Void.new(),
+              SCSpecType.new(:SC_SPEC_TYPE_VAL)
+            )
+            |> SCSpecTypeSet.new(),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_SET),
           binary: <<0, 0, 3, 235, 0, 0, 0, 0>>
         },
@@ -124,12 +130,11 @@ defmodule StellarBase.XDR.SCSpecTypeDefTest do
         },
         %{
           sc_code:
-            SCSpecTypeTuple.new(
-              SCSpecTypeDef12.new([
-                SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
-                SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
-              ])
-            ),
+            SCSpecTypeDef12.new([
+              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
+              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+            ])
+            |> SCSpecTypeTuple.new(),
           status_type: SCSpecType.new(:SC_SPEC_TYPE_TUPLE),
           binary: <<0, 0, 3, 237, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5>>
         },

--- a/test/xdr/contract/spec/sc_spec_type_def_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_def_test.exs
@@ -1,0 +1,190 @@
+defmodule StellarBase.XDR.SCSpecTypeDefTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    SCSpecTypeDef,
+    SCSpecType,
+    SCSpecTypeVec,
+    SCSpecTypeMap,
+    SCSpecTypeSet,
+    SCSpecTypeTuple,
+    SCSpecTypeBytesN,
+    SCSpecTypeUDT,
+    SCSpecTypeOption,
+    SCSpecTypeResult,
+    SCSpecTypeDef12,
+    UInt32,
+    Void,
+    String60
+  }
+
+  describe "SCSpecTypeDef" do
+    setup do
+      discriminants = [
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_VAL),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 0>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_U32),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 1>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_I32),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 2>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_U64),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 3>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_I64),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 4>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_U128),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 5>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_I128),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 6>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_BOOL),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 7>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_SYMBOL),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 8>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_BITSET),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 9>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_STATUS),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 10>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_BYTES),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 11>>
+        },
+        %{
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_ADDRESS),
+          sc_code: Void.new(),
+          binary: <<0, 0, 0, 13>>
+        },
+        %{
+          sc_code:
+            SCSpecTypeOption.new(SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))),
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_OPTION),
+          binary: <<0, 0, 3, 232, 0, 0, 0, 0>>
+        },
+        %{
+          sc_code:
+            SCSpecTypeResult.new(
+              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
+              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+            ),
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_RESULT),
+          binary: <<0, 0, 3, 233, 0, 0, 0, 0, 0, 0, 0, 5>>
+        },
+        %{
+          sc_code:
+            SCSpecTypeVec.new(SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))),
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_VEC),
+          binary: <<0, 0, 3, 234, 0, 0, 0, 0>>
+        },
+        %{
+          sc_code:
+            SCSpecTypeSet.new(SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))),
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_SET),
+          binary: <<0, 0, 3, 235, 0, 0, 0, 0>>
+        },
+        %{
+          sc_code:
+            SCSpecTypeMap.new(
+              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
+              SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+            ),
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_MAP),
+          binary: <<0, 0, 3, 236, 0, 0, 0, 0, 0, 0, 0, 5>>
+        },
+        %{
+          sc_code:
+            SCSpecTypeTuple.new(
+              SCSpecTypeDef12.new([
+                SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
+                SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+              ])
+            ),
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_TUPLE),
+          binary: <<0, 0, 3, 237, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5>>
+        },
+        %{
+          sc_code: SCSpecTypeBytesN.new(UInt32.new(1)),
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_BYTES_N),
+          binary: <<0, 0, 3, 238, 0, 0, 0, 1>>
+        },
+        %{
+          sc_code: SCSpecTypeUDT.new(String60.new("Hello")),
+          status_type: SCSpecType.new(:SC_SPEC_TYPE_UDT),
+          binary: <<0, 0, 7, 208, 0, 0, 0, 5, 72, 101, 108, 108, 111, 0, 0, 0>>
+        }
+      ]
+
+      %{discriminants: discriminants}
+    end
+
+    test "new/2", %{discriminants: discriminants} do
+      for %{status_type: status_type, sc_code: sc_code} <- discriminants do
+        %SCSpecTypeDef{code: ^sc_code, type: ^status_type} =
+          SCSpecTypeDef.new(sc_code, status_type)
+      end
+    end
+
+    test "encode_xdr/1", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, status_type: status_type, binary: binary} <- discriminants do
+        xdr = SCSpecTypeDef.new(sc_code, status_type)
+        {:ok, ^binary} = SCSpecTypeDef.encode_xdr(xdr)
+      end
+    end
+
+    test "encode_xdr!/1", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, status_type: status_type, binary: binary} <- discriminants do
+        xdr = SCSpecTypeDef.new(sc_code, status_type)
+        ^binary = SCSpecTypeDef.encode_xdr!(xdr)
+      end
+    end
+
+    test "decode_xdr/2", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, status_type: status_type, binary: binary} <- discriminants do
+        xdr = SCSpecTypeDef.new(sc_code, status_type)
+        {:ok, {^xdr, ""}} = SCSpecTypeDef.decode_xdr(binary)
+      end
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeDef.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{discriminants: discriminants} do
+      for %{sc_code: sc_code, status_type: status_type, binary: binary} <- discriminants do
+        xdr = SCSpecTypeDef.new(sc_code, status_type)
+        {^xdr, ""} = SCSpecTypeDef.decode_xdr!(binary)
+      end
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_map_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_map_test.exs
@@ -1,0 +1,56 @@
+defmodule StellarBase.XDR.SCSpecTypeMapTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{SCSpecType, SCSpecTypeDef, SCSpecTypeMap, Void}
+
+  describe "SCSpecTypeMap" do
+    setup do
+      keyType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      valueType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+
+      %{
+        keyType: keyType,
+        valueType: valueType,
+        sc_spec_type_map: SCSpecTypeMap.new(keyType, valueType),
+        binary: <<0, 0, 0, 0, 0, 0, 0, 0>>
+      }
+    end
+
+    test "new/2", %{keyType: keyType, valueType: valueType} do
+      %SCSpecTypeMap{keyType: ^keyType, valueType: ^valueType} =
+        SCSpecTypeMap.new(keyType, valueType)
+    end
+
+    test "encode_xdr/1", %{
+      sc_spec_type_map: sc_spec_type_map,
+      binary: binary
+    } do
+      {:ok, ^binary} = SCSpecTypeMap.encode_xdr(sc_spec_type_map)
+    end
+
+    test "encode_xdr!/1", %{
+      sc_spec_type_map: sc_spec_type_map,
+      binary: binary
+    } do
+      ^binary = SCSpecTypeMap.encode_xdr!(sc_spec_type_map)
+    end
+
+    test "decode_xdr/2", %{
+      sc_spec_type_map: sc_spec_type_map,
+      binary: binary
+    } do
+      {:ok, {^sc_spec_type_map, ""}} = SCSpecTypeMap.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeMap.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{
+      sc_spec_type_map: sc_spec_type_map,
+      binary: binary
+    } do
+      {^sc_spec_type_map, ^binary} = SCSpecTypeMap.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_map_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_map_test.exs
@@ -5,20 +5,20 @@ defmodule StellarBase.XDR.SCSpecTypeMapTest do
 
   describe "SCSpecTypeMap" do
     setup do
-      keyType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
-      valueType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      key_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      value_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
 
       %{
-        keyType: keyType,
-        valueType: valueType,
-        sc_spec_type_map: SCSpecTypeMap.new(keyType, valueType),
+        key_type: key_type,
+        value_type: value_type,
+        sc_spec_type_map: SCSpecTypeMap.new(key_type, value_type),
         binary: <<0, 0, 0, 0, 0, 0, 0, 0>>
       }
     end
 
-    test "new/2", %{keyType: keyType, valueType: valueType} do
-      %SCSpecTypeMap{keyType: ^keyType, valueType: ^valueType} =
-        SCSpecTypeMap.new(keyType, valueType)
+    test "new/2", %{key_type: key_type, value_type: value_type} do
+      %SCSpecTypeMap{key_type: ^key_type, value_type: ^value_type} =
+        SCSpecTypeMap.new(key_type, value_type)
     end
 
     test "encode_xdr/1", %{

--- a/test/xdr/contract/spec/sc_spec_type_map_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_map_test.exs
@@ -5,8 +5,12 @@ defmodule StellarBase.XDR.SCSpecTypeMapTest do
 
   describe "SCSpecTypeMap" do
     setup do
-      key_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
-      value_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      code = Void.new()
+      type = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      sc_spec_type_def = SCSpecTypeDef.new(code, type)
+
+      key_type = sc_spec_type_def
+      value_type = sc_spec_type_def
 
       %{
         key_type: key_type,

--- a/test/xdr/contract/spec/sc_spec_type_option_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_option_test.exs
@@ -5,17 +5,17 @@ defmodule StellarBase.XDR.SCSpecTypeOptionTest do
 
   describe "SCSpecTypeOption" do
     setup do
-      valueType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      value_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
 
       %{
-        valueType: valueType,
-        sc_spec_type_map: SCSpecTypeOption.new(valueType),
+        value_type: value_type,
+        sc_spec_type_map: SCSpecTypeOption.new(value_type),
         binary: <<0, 0, 0, 0>>
       }
     end
 
-    test "new/1", %{valueType: valueType} do
-      %SCSpecTypeOption{valueType: ^valueType} = SCSpecTypeOption.new(valueType)
+    test "new/1", %{value_type: value_type} do
+      %SCSpecTypeOption{value_type: ^value_type} = SCSpecTypeOption.new(value_type)
     end
 
     test "encode_xdr/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do

--- a/test/xdr/contract/spec/sc_spec_type_option_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_option_test.exs
@@ -1,0 +1,41 @@
+defmodule StellarBase.XDR.SCSpecTypeOptionTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{SCSpecType, SCSpecTypeDef, SCSpecTypeOption, Void}
+
+  describe "SCSpecTypeOption" do
+    setup do
+      valueType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+
+      %{
+        valueType: valueType,
+        sc_spec_type_map: SCSpecTypeOption.new(valueType),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{valueType: valueType} do
+      %SCSpecTypeOption{valueType: ^valueType} = SCSpecTypeOption.new(valueType)
+    end
+
+    test "encode_xdr/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {:ok, ^binary} = SCSpecTypeOption.encode_xdr(sc_spec_type_map)
+    end
+
+    test "encode_xdr!/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      ^binary = SCSpecTypeOption.encode_xdr!(sc_spec_type_map)
+    end
+
+    test "decode_xdr/2", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {:ok, {^sc_spec_type_map, ""}} = SCSpecTypeOption.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeOption.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {^sc_spec_type_map, ^binary} = SCSpecTypeOption.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_option_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_option_test.exs
@@ -5,7 +5,10 @@ defmodule StellarBase.XDR.SCSpecTypeOptionTest do
 
   describe "SCSpecTypeOption" do
     setup do
-      value_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      code = Void.new()
+      type = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+
+      value_type = SCSpecTypeDef.new(code, type)
 
       %{
         value_type: value_type,

--- a/test/xdr/contract/spec/sc_spec_type_result_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_result_test.exs
@@ -5,8 +5,11 @@ defmodule StellarBase.XDR.SCSpecTypeResultTest do
 
   describe "SCSpecTypeResult" do
     setup do
-      ok_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
-      error_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      code = Void.new()
+      type = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      sc_spec_type_def = SCSpecTypeDef.new(code, type)
+      ok_type = sc_spec_type_def
+      error_type = sc_spec_type_def
 
       %{
         ok_type: ok_type,

--- a/test/xdr/contract/spec/sc_spec_type_result_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_result_test.exs
@@ -1,0 +1,56 @@
+defmodule StellarBase.XDR.SCSpecTypeResultTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{SCSpecType, SCSpecTypeDef, SCSpecTypeResult, Void}
+
+  describe "SCSpecTypeResult" do
+    setup do
+      okType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      errorType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+
+      %{
+        okType: okType,
+        errorType: errorType,
+        sc_spec_type_map: SCSpecTypeResult.new(okType, errorType),
+        binary: <<0, 0, 0, 0, 0, 0, 0, 0>>
+      }
+    end
+
+    test "new/2", %{okType: okType, errorType: errorType} do
+      %SCSpecTypeResult{okType: ^okType, errorType: ^errorType} =
+        SCSpecTypeResult.new(okType, errorType)
+    end
+
+    test "encode_xdr/1", %{
+      sc_spec_type_map: sc_spec_type_map,
+      binary: binary
+    } do
+      {:ok, ^binary} = SCSpecTypeResult.encode_xdr(sc_spec_type_map)
+    end
+
+    test "encode_xdr!/1", %{
+      sc_spec_type_map: sc_spec_type_map,
+      binary: binary
+    } do
+      ^binary = SCSpecTypeResult.encode_xdr!(sc_spec_type_map)
+    end
+
+    test "decode_xdr/2", %{
+      sc_spec_type_map: sc_spec_type_map,
+      binary: binary
+    } do
+      {:ok, {^sc_spec_type_map, ""}} = SCSpecTypeResult.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeResult.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{
+      sc_spec_type_map: sc_spec_type_map,
+      binary: binary
+    } do
+      {^sc_spec_type_map, ^binary} = SCSpecTypeResult.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_result_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_result_test.exs
@@ -5,20 +5,20 @@ defmodule StellarBase.XDR.SCSpecTypeResultTest do
 
   describe "SCSpecTypeResult" do
     setup do
-      okType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
-      errorType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      ok_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      error_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
 
       %{
-        okType: okType,
-        errorType: errorType,
-        sc_spec_type_map: SCSpecTypeResult.new(okType, errorType),
+        ok_type: ok_type,
+        error_type: error_type,
+        sc_spec_type_map: SCSpecTypeResult.new(ok_type, error_type),
         binary: <<0, 0, 0, 0, 0, 0, 0, 0>>
       }
     end
 
-    test "new/2", %{okType: okType, errorType: errorType} do
-      %SCSpecTypeResult{okType: ^okType, errorType: ^errorType} =
-        SCSpecTypeResult.new(okType, errorType)
+    test "new/2", %{ok_type: ok_type, error_type: error_type} do
+      %SCSpecTypeResult{ok_type: ^ok_type, error_type: ^error_type} =
+        SCSpecTypeResult.new(ok_type, error_type)
     end
 
     test "encode_xdr/1", %{

--- a/test/xdr/contract/spec/sc_spec_type_set_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_set_test.exs
@@ -5,17 +5,17 @@ defmodule StellarBase.XDR.SCSpecTypeSetTest do
 
   describe "SCSpecTypeSet" do
     setup do
-      elementType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      element_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
 
       %{
-        elementType: elementType,
-        sc_spec_type_map: SCSpecTypeSet.new(elementType),
+        element_type: element_type,
+        sc_spec_type_map: SCSpecTypeSet.new(element_type),
         binary: <<0, 0, 0, 0>>
       }
     end
 
-    test "new/1", %{elementType: elementType} do
-      %SCSpecTypeSet{elementType: ^elementType} = SCSpecTypeSet.new(elementType)
+    test "new/1", %{element_type: element_type} do
+      %SCSpecTypeSet{element_type: ^element_type} = SCSpecTypeSet.new(element_type)
     end
 
     test "encode_xdr/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do

--- a/test/xdr/contract/spec/sc_spec_type_set_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_set_test.exs
@@ -1,0 +1,41 @@
+defmodule StellarBase.XDR.SCSpecTypeSetTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{SCSpecType, SCSpecTypeDef, SCSpecTypeSet, Void}
+
+  describe "SCSpecTypeSet" do
+    setup do
+      elementType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+
+      %{
+        elementType: elementType,
+        sc_spec_type_map: SCSpecTypeSet.new(elementType),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{elementType: elementType} do
+      %SCSpecTypeSet{elementType: ^elementType} = SCSpecTypeSet.new(elementType)
+    end
+
+    test "encode_xdr/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {:ok, ^binary} = SCSpecTypeSet.encode_xdr(sc_spec_type_map)
+    end
+
+    test "encode_xdr!/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      ^binary = SCSpecTypeSet.encode_xdr!(sc_spec_type_map)
+    end
+
+    test "decode_xdr/2", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {:ok, {^sc_spec_type_map, ""}} = SCSpecTypeSet.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeSet.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {^sc_spec_type_map, ^binary} = SCSpecTypeSet.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_set_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_set_test.exs
@@ -5,7 +5,10 @@ defmodule StellarBase.XDR.SCSpecTypeSetTest do
 
   describe "SCSpecTypeSet" do
     setup do
-      element_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      code = Void.new()
+      type = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+
+      element_type = SCSpecTypeDef.new(code, type)
 
       %{
         element_type: element_type,

--- a/test/xdr/contract/spec/sc_spec_type_tuple_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_tuple_test.exs
@@ -5,11 +5,13 @@ defmodule StellarBase.XDR.SCSpecTypeTupleTest do
 
   describe "SCSpecTypeTuple" do
     setup do
-      value_types =
-        SCSpecTypeDef12.new([
-          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
-          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
-        ])
+      code = Void.new()
+      type_val = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      type_u128 = SCSpecType.new(:SC_SPEC_TYPE_U128)
+      sc_spec_type_def_1 = SCSpecTypeDef.new(code, type_val)
+      sc_spec_type_def_2 = SCSpecTypeDef.new(code, type_u128)
+
+      value_types = SCSpecTypeDef12.new([sc_spec_type_def_1, sc_spec_type_def_2])
 
       %{
         value_types: value_types,

--- a/test/xdr/contract/spec/sc_spec_type_tuple_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_tuple_test.exs
@@ -5,21 +5,21 @@ defmodule StellarBase.XDR.SCSpecTypeTupleTest do
 
   describe "SCSpecTypeTuple" do
     setup do
-      valueTypes =
+      value_types =
         SCSpecTypeDef12.new([
           SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
           SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
         ])
 
       %{
-        valueTypes: valueTypes,
-        sc_spec_type_map: SCSpecTypeTuple.new(valueTypes),
+        value_types: value_types,
+        sc_spec_type_map: SCSpecTypeTuple.new(value_types),
         binary: <<0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5>>
       }
     end
 
-    test "new/1", %{valueTypes: valueTypes} do
-      %SCSpecTypeTuple{valueTypes: ^valueTypes} = SCSpecTypeTuple.new(valueTypes)
+    test "new/1", %{value_types: value_types} do
+      %SCSpecTypeTuple{value_types: ^value_types} = SCSpecTypeTuple.new(value_types)
     end
 
     test "encode_xdr/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do

--- a/test/xdr/contract/spec/sc_spec_type_tuple_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_tuple_test.exs
@@ -1,0 +1,45 @@
+defmodule StellarBase.XDR.SCSpecTypeTupleTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{SCSpecType, SCSpecTypeDef, SCSpecTypeTuple, SCSpecTypeDef12, Void}
+
+  describe "SCSpecTypeTuple" do
+    setup do
+      valueTypes =
+        SCSpecTypeDef12.new([
+          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
+          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+        ])
+
+      %{
+        valueTypes: valueTypes,
+        sc_spec_type_map: SCSpecTypeTuple.new(valueTypes),
+        binary: <<0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5>>
+      }
+    end
+
+    test "new/1", %{valueTypes: valueTypes} do
+      %SCSpecTypeTuple{valueTypes: ^valueTypes} = SCSpecTypeTuple.new(valueTypes)
+    end
+
+    test "encode_xdr/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {:ok, ^binary} = SCSpecTypeTuple.encode_xdr(sc_spec_type_map)
+    end
+
+    test "encode_xdr!/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      ^binary = SCSpecTypeTuple.encode_xdr!(sc_spec_type_map)
+    end
+
+    test "decode_xdr/2", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {:ok, {^sc_spec_type_map, ""}} = SCSpecTypeTuple.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeTuple.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {^sc_spec_type_map, ^binary} = SCSpecTypeTuple.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_type_vec_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_vec_test.exs
@@ -5,7 +5,10 @@ defmodule StellarBase.XDR.SCSpecTypeVecTest do
 
   describe "SCSpecTypeVec" do
     setup do
-      element_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      code = Void.new()
+      type = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+
+      element_type = SCSpecTypeDef.new(code, type)
 
       %{
         element_type: element_type,

--- a/test/xdr/contract/spec/sc_spec_type_vec_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_vec_test.exs
@@ -5,17 +5,17 @@ defmodule StellarBase.XDR.SCSpecTypeVecTest do
 
   describe "SCSpecTypeVec" do
     setup do
-      elementType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+      element_type = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
 
       %{
-        elementType: elementType,
-        sc_spec_type_map: SCSpecTypeVec.new(elementType),
+        element_type: element_type,
+        sc_spec_type_map: SCSpecTypeVec.new(element_type),
         binary: <<0, 0, 0, 0>>
       }
     end
 
-    test "new/1", %{elementType: elementType} do
-      %SCSpecTypeVec{elementType: ^elementType} = SCSpecTypeVec.new(elementType)
+    test "new/1", %{element_type: element_type} do
+      %SCSpecTypeVec{element_type: ^element_type} = SCSpecTypeVec.new(element_type)
     end
 
     test "encode_xdr/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do

--- a/test/xdr/contract/spec/sc_spec_type_vec_test.exs
+++ b/test/xdr/contract/spec/sc_spec_type_vec_test.exs
@@ -1,0 +1,41 @@
+defmodule StellarBase.XDR.SCSpecTypeVecTest do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{SCSpecType, SCSpecTypeDef, SCSpecTypeVec, Void}
+
+  describe "SCSpecTypeVec" do
+    setup do
+      elementType = SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL))
+
+      %{
+        elementType: elementType,
+        sc_spec_type_map: SCSpecTypeVec.new(elementType),
+        binary: <<0, 0, 0, 0>>
+      }
+    end
+
+    test "new/1", %{elementType: elementType} do
+      %SCSpecTypeVec{elementType: ^elementType} = SCSpecTypeVec.new(elementType)
+    end
+
+    test "encode_xdr/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {:ok, ^binary} = SCSpecTypeVec.encode_xdr(sc_spec_type_map)
+    end
+
+    test "encode_xdr!/1", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      ^binary = SCSpecTypeVec.encode_xdr!(sc_spec_type_map)
+    end
+
+    test "decode_xdr/2", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {:ok, {^sc_spec_type_map, ""}} = SCSpecTypeVec.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecTypeVec.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{sc_spec_type_map: sc_spec_type_map, binary: binary} do
+      {^sc_spec_type_map, ^binary} = SCSpecTypeVec.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_udt_union_case_tuple_v0_test.exs
+++ b/test/xdr/contract/spec/sc_spec_udt_union_case_tuple_v0_test.exs
@@ -1,0 +1,75 @@
+defmodule StellarBase.XDR.SCSpecUDTUnionCaseTupleV0Test do
+  use ExUnit.Case
+
+  alias StellarBase.XDR.{
+    String1024,
+    String60,
+    SCSpecUDTUnionCaseTupleV0,
+    SCSpecTypeDef12,
+    SCSpecTypeDef,
+    SCSpecType,
+    Void
+  }
+
+  describe "SCSpecUDTUnionCaseTupleV0" do
+    setup do
+      doc = String1024.new("Hello there this is a test")
+      name = String60.new("Hello there")
+
+      type =
+        SCSpecTypeDef12.new([
+          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
+          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
+        ])
+
+      %{
+        doc: doc,
+        name: name,
+        type: type,
+        sc_spec_udt_union_case_tuple_v0: SCSpecUDTUnionCaseTupleV0.new(doc, name, type),
+        binary:
+          <<0, 0, 0, 26, 72, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101, 32, 116, 104, 105,
+            115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 0, 0, 0, 0, 0, 11, 72, 101, 108,
+            108, 111, 32, 116, 104, 101, 114, 101, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5>>
+      }
+    end
+
+    test "new/3", %{doc: doc, name: name, type: type} do
+      %SCSpecUDTUnionCaseTupleV0{doc: ^doc, name: ^name, type: ^type} =
+        SCSpecUDTUnionCaseTupleV0.new(doc, name, type)
+    end
+
+    test "encode_xdr/1", %{
+      sc_spec_udt_union_case_tuple_v0: sc_spec_udt_union_case_tuple_v0,
+      binary: binary
+    } do
+      {:ok, ^binary} = SCSpecUDTUnionCaseTupleV0.encode_xdr(sc_spec_udt_union_case_tuple_v0)
+    end
+
+    test "encode_xdr!/1", %{
+      sc_spec_udt_union_case_tuple_v0: sc_spec_udt_union_case_tuple_v0,
+      binary: binary
+    } do
+      ^binary = SCSpecUDTUnionCaseTupleV0.encode_xdr!(sc_spec_udt_union_case_tuple_v0)
+    end
+
+    test "decode_xdr/2", %{
+      sc_spec_udt_union_case_tuple_v0: sc_spec_udt_union_case_tuple_v0,
+      binary: binary
+    } do
+      {:ok, {^sc_spec_udt_union_case_tuple_v0, ""}} = SCSpecUDTUnionCaseTupleV0.decode_xdr(binary)
+    end
+
+    test "decode_xdr/2 with an invalid binary" do
+      {:error, :not_binary} = SCSpecUDTUnionCaseTupleV0.decode_xdr(123)
+    end
+
+    test "decode_xdr!/2", %{
+      sc_spec_udt_union_case_tuple_v0: sc_spec_udt_union_case_tuple_v0,
+      binary: binary
+    } do
+      {^sc_spec_udt_union_case_tuple_v0, ^binary} =
+        SCSpecUDTUnionCaseTupleV0.decode_xdr!(binary <> binary)
+    end
+  end
+end

--- a/test/xdr/contract/spec/sc_spec_udt_union_case_tuple_v0_test.exs
+++ b/test/xdr/contract/spec/sc_spec_udt_union_case_tuple_v0_test.exs
@@ -15,12 +15,13 @@ defmodule StellarBase.XDR.SCSpecUDTUnionCaseTupleV0Test do
     setup do
       doc = String1024.new("Hello there this is a test")
       name = String60.new("Hello there")
+      code = Void.new()
+      type_val = SCSpecType.new(:SC_SPEC_TYPE_VAL)
+      type_u128 = SCSpecType.new(:SC_SPEC_TYPE_U128)
+      sc_spec_type_def1 = SCSpecTypeDef.new(code, type_val)
+      sc_spec_type_def2 = SCSpecTypeDef.new(code, type_u128)
 
-      type =
-        SCSpecTypeDef12.new([
-          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_VAL)),
-          SCSpecTypeDef.new(Void.new(), SCSpecType.new(:SC_SPEC_TYPE_U128))
-        ])
+      type = SCSpecTypeDef12.new([sc_spec_type_def1, sc_spec_type_def2])
 
       %{
         doc: doc,


### PR DESCRIPTION
Contributing to https://github.com/kommitters/stellar_base/issues/228

In this PR, the following types were added:

SCSpecFunctionInputV0
SCSpecFunctionV0
SCSpecTypeDef
SCSpecTypeMap
SCSpecTypeOption
SCSpecTypeResult
SCSpecTypeVec
SCSpecTypeSet
SCSpecTypeTuple
SCSpecUDTUnionCaseTupleV0
SCSpecTypeDef12
SCSpecTypeDef1
SCSpecFunctionInputV0List