### PR TITLE
Add missing value types in SCVal

### DIFF
--- a/lib/xdr/contract/sc_val.ex
+++ b/lib/xdr/contract/sc_val.ex
@@ -70,6 +70,8 @@ defmodule StellarBase.XDR.SCVal do
           | Int64.t()
           | TimePoint.t()
           | Duration.t()
+          | Int128Parts.t()
+          | Int256Parts.t()
           | UInt128Parts.t()
           | UInt256Parts.t()
           | SCBytes.t()


### PR DESCRIPTION
Added missing types in `sc_val` since they are used in stellar_sdk and were generating unexpected warnings