### PR TITLE
CD fix up elixir version update

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         otp: ['23.3']
-        elixir: ['1.11']
+        elixir: ['1.13']
     env:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
     steps:


### PR DESCRIPTION
## Context

Since the CD is failing to compile `:nimble_parsec` with elixir `v1.11` we tested it with the `act cli` locally with the following command `act --job publish` verifying that the new set version(`v1.13`) doesn't retrieve any warnings and compiles successfully before publishing the package in hex.docs. 